### PR TITLE
Enable sessions to bypass creating/parsing cookies.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -181,3 +181,4 @@ Patches and Suggestions
 - Jonathan Vanasco (`@jvanasco <https://github.com/jvanasco>`_)
 - David Fontenot (`@davidfontenot <https://github.com/davidfontenot>`_)
 - Shmuel Amar (`@shmuelamar <https://github.com/shmuelamar>`_)
+- Roy Williams(`@rowillia <https://github.com/rowillia`_)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -43,8 +43,6 @@ Release History
   check doesn't use forward and reverse DNS requests anymore
 - URLs with schemes that begin with ``http`` but are not ``http`` or ``https``
   no longer have their host parts forced to lowercase.
-- Enable ``Session`` objects to skip creating or parsing cookies all together.
-  This will improve performance for users who don't use cookies.
 
 **Bugfixes**
 
@@ -1369,3 +1367,4 @@ This is not a backwards compatible change.
 
 * Frustration
 * Conception
+

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ---------------
 
+**Unreleased**
++++++++++++++++++++
+
+- Enable ``Session`` objects to skip creating or parsing cookies all together.
+  This will improve performance for users who don't use cookies.
+
 2.14.2 (2017-05-10)
 +++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -43,6 +43,8 @@ Release History
   check doesn't use forward and reverse DNS requests anymore
 - URLs with schemes that begin with ``http`` but are not ``http`` or ``https``
   no longer have their host parts forced to lowercase.
+- Enable ``Session`` objects to skip creating or parsing cookies all together.
+  This will improve performance for users who don't use cookies.
 
 **Bugfixes**
 
@@ -1367,4 +1369,3 @@ This is not a backwards compatible change.
 
 * Frustration
 * Conception
-

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -277,7 +277,8 @@ class HTTPAdapter(BaseAdapter):
             response.url = req.url
 
         # Add new cookies from the server.
-        extract_cookies_to_jar(response.cookies, req, resp)
+        if not req.discard_cookies:
+            extract_cookies_to_jar(response.cookies, req, resp)
 
         # Give the Response some context.
         response.request = req

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -248,7 +248,7 @@ class HTTPAdapter(BaseAdapter):
                 raise IOError("Could not find the TLS key file, "
                               "invalid path: {0}".format(conn.key_file))
 
-    def build_response(self, req, resp):
+    def build_response(self, req, resp, discard_cookies=False):
         """Builds a :class:`Response <requests.Response>` object from a urllib3
         response. This should not be called from user code, and is only exposed
         for use when subclassing the
@@ -277,7 +277,7 @@ class HTTPAdapter(BaseAdapter):
             response.url = req.url
 
         # Add new cookies from the server.
-        if not req.discard_cookies:
+        if not discard_cookies:
             extract_cookies_to_jar(response.cookies, req, resp)
 
         # Give the Response some context.
@@ -384,7 +384,8 @@ class HTTPAdapter(BaseAdapter):
 
         return headers
 
-    def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):
+    def send(self, request, stream=False, timeout=None, verify=True, cert=None,
+             proxies=None, discard_cookies=False):
         """Sends PreparedRequest object. Returns Response object.
 
         :param request: The :class:`PreparedRequest <PreparedRequest>` being sent.
@@ -516,4 +517,4 @@ class HTTPAdapter(BaseAdapter):
             else:
                 raise
 
-        return self.build_response(request, resp)
+        return self.build_response(request, resp, discard_cookies)

--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -123,8 +123,8 @@ def extract_cookies_to_jar(jar, request, response):
     :param request: our own requests.Request object
     :param response: urllib3.HTTPResponse object
     """
-    if not (hasattr(response, '_original_response') and
-            response._original_response):
+    if jar is None or not (hasattr(response, '_original_response') and
+                           response._original_response):
         return
     # the _original_response field is the wrapped httplib.HTTPResponse object,
     req = MockRequest(request)
@@ -524,12 +524,19 @@ def merge_cookies(cookiejar, cookies):
     :param cookiejar: CookieJar object to add the cookies to.
     :param cookies: Dictionary or CookieJar object to be added.
     """
+
+    if cookiejar is None:
+        if cookies is None:
+            return None
+        cookiejar = RequestsCookieJar()
+
     if not isinstance(cookiejar, cookielib.CookieJar):
         raise ValueError('You can only merge into CookieJar')
 
     if isinstance(cookies, dict):
         cookiejar = cookiejar_from_dict(
             cookies, cookiejar=cookiejar, overwrite=False)
+
     elif isinstance(cookies, cookielib.CookieJar):
         try:
             cookiejar.update(cookies)

--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -123,8 +123,10 @@ def extract_cookies_to_jar(jar, request, response):
     :param request: our own requests.Request object
     :param response: urllib3.HTTPResponse object
     """
-    if jar is None or not (hasattr(response, '_original_response') and
-                           response._original_response):
+    if jar is None:
+        return
+    if not (hasattr(response, '_original_response') and
+            response._original_response):
         return
     # the _original_response field is the wrapped httplib.HTTPResponse object,
     req = MockRequest(request)
@@ -536,7 +538,6 @@ def merge_cookies(cookiejar, cookies):
     if isinstance(cookies, dict):
         cookiejar = cookiejar_from_dict(
             cookies, cookiejar=cookiejar, overwrite=False)
-
     elif isinstance(cookies, cookielib.CookieJar):
         try:
             cookiejar.update(cookies)

--- a/requests/models.py
+++ b/requests/models.py
@@ -293,15 +293,18 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         self.hooks = default_hooks()
         #: integer denoting starting position of a readable file-like body.
         self._body_position = None
+        #: boolean denoting whether or not to discard cookies from the response.
+        self.discard_cookies = False
 
     def prepare(self, method=None, url=None, headers=None, files=None,
-        data=None, params=None, auth=None, cookies=None, hooks=None, json=None):
+        data=None, params=None, auth=None, cookies=None, hooks=None, json=None,
+        discard_cookies=False):
         """Prepares the entire request with the given parameters."""
 
         self.prepare_method(method)
         self.prepare_url(url, params)
         self.prepare_headers(headers)
-        self.prepare_cookies(cookies)
+        self.prepare_cookies(cookies, discard_cookies)
         self.prepare_body(data, files, json)
         self.prepare_auth(auth, url)
 
@@ -323,6 +326,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         p.body = self.body
         p.hooks = self.hooks
         p._body_position = self._body_position
+        p.discard_cookies = self.discard_cookies
         return p
 
     def prepare_method(self, method):
@@ -548,17 +552,21 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             # Recompute Content-Length
             self.prepare_content_length(self.body)
 
-    def prepare_cookies(self, cookies):
+    def prepare_cookies(self, cookies, discard_cookies=False):
         """Prepares the given HTTP cookie data.
 
         This function eventually generates a ``Cookie`` header from the
-        given cookies using cookielib. Due to cookielib's design, the header
+        given cookies using cookielib. If `cookies` is None, no ``Cookie``
+        header will be added.  Due to cookielib's design, the header
         will not be regenerated if it already exists, meaning this function
         can only be called once for the life of the
         :class:`PreparedRequest <PreparedRequest>` object. Any subsequent calls
         to ``prepare_cookies`` will have no actual effect, unless the "Cookie"
         header is removed beforehand.
         """
+        self.discard_cookies = discard_cookies
+        if cookies is None:
+            return
         if isinstance(cookies, cookielib.CookieJar):
             self._cookies = cookies
         else:

--- a/requests/models.py
+++ b/requests/models.py
@@ -293,18 +293,15 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         self.hooks = default_hooks()
         #: integer denoting starting position of a readable file-like body.
         self._body_position = None
-        #: boolean denoting whether or not to discard cookies from the response.
-        self.discard_cookies = False
 
     def prepare(self, method=None, url=None, headers=None, files=None,
-        data=None, params=None, auth=None, cookies=None, hooks=None, json=None,
-        discard_cookies=False):
+        data=None, params=None, auth=None, cookies=None, hooks=None, json=None):
         """Prepares the entire request with the given parameters."""
 
         self.prepare_method(method)
         self.prepare_url(url, params)
         self.prepare_headers(headers)
-        self.prepare_cookies(cookies, discard_cookies)
+        self.prepare_cookies(cookies)
         self.prepare_body(data, files, json)
         self.prepare_auth(auth, url)
 
@@ -326,7 +323,6 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         p.body = self.body
         p.hooks = self.hooks
         p._body_position = self._body_position
-        p.discard_cookies = self.discard_cookies
         return p
 
     def prepare_method(self, method):
@@ -552,7 +548,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             # Recompute Content-Length
             self.prepare_content_length(self.body)
 
-    def prepare_cookies(self, cookies, discard_cookies=False):
+    def prepare_cookies(self, cookies):
         """Prepares the given HTTP cookie data.
 
         This function eventually generates a ``Cookie`` header from the
@@ -564,7 +560,6 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         to ``prepare_cookies`` will have no actual effect, unless the "Cookie"
         header is removed beforehand.
         """
-        self.discard_cookies = discard_cookies
         if cookies is None:
             return
         if isinstance(cookies, cookielib.CookieJar):

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -438,7 +438,6 @@ class Session(SessionRedirectMixin):
             auth=merge_setting(auth, self.auth),
             cookies=merged_cookies,
             hooks=merge_hooks(request.hooks, self.hooks),
-            discard_cookies=self.cookies is None
         )
         return p
 
@@ -613,6 +612,9 @@ class Session(SessionRedirectMixin):
         kwargs.setdefault('verify', self.verify)
         kwargs.setdefault('cert', self.cert)
         kwargs.setdefault('proxies', self.proxies)
+        # If the cookie jar on the session is None, skip
+        # parsing cookies on the response.
+        kwargs.setdefault('discard_cookies', self.cookies is None)
 
         # It's possible that users might accidentally send a Request object.
         # Guard against that specific failure case.

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -367,6 +367,14 @@ class TestRequests:
         # Session cookie should still be None
         assert s.cookies is None
 
+    def test_session_with_none_cookies_discards_server_cookies(self, httpbin):
+        s = requests.session()
+        s.cookies = None
+        r = s.get(httpbin('cookies/set?cookie=value'))
+        assert r.json()['cookies'] == {}
+        # Session cookie should still be None
+        assert s.cookies is None
+
     def test_request_cookies_not_persisted(self, httpbin):
         s = requests.session()
         s.get(httpbin('cookies'), cookies={'foo': 'baz'})

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -351,6 +351,22 @@ class TestRequests:
         # Session cookie should not be modified
         assert s.cookies['foo'] == 'bar'
 
+    def test_session_with_explicitly_none_cookies_takes_request(self, httpbin):
+        s = requests.session()
+        s.cookies = None
+        r = s.get(httpbin('cookies'), cookies={'foo': 'baz'})
+        assert r.json()['cookies']['foo'] == 'baz'
+        # Session cookie should still be None
+        assert s.cookies is None
+
+    def test_session_with_explicitly_none_cookies(self, httpbin):
+        s = requests.session()
+        s.cookies = None
+        r = s.get(httpbin('cookies'))
+        assert r.json()['cookies'] == {}
+        # Session cookie should still be None
+        assert s.cookies is None
+
     def test_request_cookies_not_persisted(self, httpbin):
         s = requests.session()
         s.get(httpbin('cookies'), cookies={'foo': 'baz'})


### PR DESCRIPTION
We use requests for some service-to-service communication, neither side
of which utilizes cookies.  When we profiled our services, we see ~13%
of the time spend sending requests is either creating cookie jars or
extracting cookies to jars.

This PR will enable us to disable cookies for a given `requests.Session`
by setting `session.cookies = None`.  If `sessions.cookies` is None, we
won't create any cookies for the request nor will we parse them on the
response.