### PR TITLE
AttributeError error raised when `files` file-pointer (fp) resolves to None

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -187,3 +187,4 @@ Patches and Suggestions
 - Nehal J Wani (`@nehaljwani <https://github.com/nehaljwani>`_)
 - Demetrios Bairaktaris (`@DemetriosBairaktaris <https://github.com/demetriosbairaktaris>`_)
 - Darren Dormer (`@ddormer <https://github.com/ddormer>`_)
+- Rajiv Mayani (`@mayani <https://github.com/mayani>`_)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,6 +23,7 @@ dev
 - DNS resolution in proxy bypass no longer includes the username and password in
   the request. This also fixes the issue of DNS queries failing on macOS.
 - Properly normalize adapter prefixes for url comparison.
+- Passing ``None`` as a file pointer to the ``files`` param no longer raises an exception.
 
 2.18.4 (2017-08-15)
 +++++++++++++++++++

--- a/requests/models.py
+++ b/requests/models.py
@@ -155,8 +155,12 @@ class RequestEncodingMixin(object):
 
             if isinstance(fp, (str, bytes, bytearray)):
                 fdata = fp
-            else:
+            elif hasattr(fp, 'read'):
                 fdata = fp.read()
+            elif fp is None:
+                continue
+            else:
+                fdata = fp
 
             rf = RequestField(name=k, data=fdata, filename=fn, headers=fh)
             rf.make_multipart(content_type=ft)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -676,6 +676,14 @@ class TestRequests:
         with pytest.raises(ValueError):
             requests.post(url, files=['bad file data'])
 
+    def test_invalid_files_input(self, httpbin):
+
+        url = httpbin('post')
+        post = requests.post(url,
+                             files={"random-file-1": None, "random-file-2": 1})
+        assert b'name="random-file-1"' not in post.request.body
+        assert b'name="random-file-2"' in post.request.body
+
     def test_POSTBIN_SEEKED_OBJECT_WITH_NO_ITER(self, httpbin):
 
         class TestStream(object):


### PR DESCRIPTION
The library raises NoneType error when file-pointer (fp) resolves to None.

```
>>> from requests import post
>>> r = post("https://example.com", files={"file-name": None})
AttributeError: 'NoneType' object has no attribute 'read'
```

However, when a param value or json field is None they are not included in the request body.

```
>>> from requests import get
>>> r = get("https://example.com", params={"file-name": None})
>>> r.request.url
```

This commit makes the beahviour consistent for files.