### PR TITLE
move functionlocal imports in utils.py and models.py to global scope

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -16,6 +16,13 @@ import sys
 # such as in Embedded Python. See https://github.com/kennethreitz/requests/issues/3578.
 import encodings.idna
 
+try:
+    import idna as _idna
+except ImportError as _exc:
+    # Re-raised when the idna module is actually needed.
+    _idna = None
+    _idna_err = _exc
+
 from urllib3.fields import RequestField
 from urllib3.filepost import encode_multipart_formdata
 from urllib3.util import parse_url
@@ -334,11 +341,11 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
 
     @staticmethod
     def _get_idna_encoded_host(host):
-        import idna
-
+        if _idna is None:
+            raise _idna_err
         try:
-            host = idna.encode(host, uts46=True).decode('utf-8')
-        except idna.IDNAError:
+            host = _idna.encode(host, uts46=True).decode('utf-8')
+        except _idna.IDNAError:
             raise UnicodeError
         return host
 


### PR DESCRIPTION
This avoids runtime warnings when using the `requests` module for the first time when it is no longer in `sys.modules`. 

```
[...]\Lib\site-packages\requests\utils.py:164: RuntimeWarning: Parent module 'requests' not found while handling absolute import
  from netrc import netrc, NetrcParseError
[...]\Lib\site-packages\requests\utils.py:49: RuntimeWarning: Parent module 'requests' not found while handling absolute import
  import _winreg as winreg
```

Seeing this warning is very common for me, since I develop Python plugins for an application that embeds Python. To ensure that no dependencies between plugins are conflicting, every plugin develiers its own dependencies and makes sure they leave no trace in `sys.modules` and `sys.path`.