### PR TITLE
Catch error if multiprocessing is not available or is unable to determine the number of CPUs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,10 @@ dev
 
 **Bugfixes**
 
+- Resolve installation failure if multiprocessing is not available
+- Resolve tests crash if multiprocessing is not able to determine the number of CPU cores
+
+
 2.17.3 (2017-05-29)
 +++++++++++++++++++
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ from codecs import open
 
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
-from multiprocessing import cpu_count
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -17,7 +16,11 @@ class PyTest(TestCommand):
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
-        self.pytest_args = ['-n', str(cpu_count()), '--boxed']
+        try:
+            from multiprocessing import cpu_count
+            self.pytest_args = ['-n', str(cpu_count()), '--boxed']
+        except (ImportError, NotImplementedError):
+            self.pytest_args = ['-n', '1', '--boxed']
 
     def finalize_options(self):
         TestCommand.finalize_options(self)


### PR DESCRIPTION
resolves #4113 