### PR TITLE
Drop python2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
@@ -14,16 +13,14 @@ python:
 install: "make"
 # command to run tests
 script:
-  - |
-    if [[ "$TRAVIS_PYTHON_VERSION" != "2.6" ]] ; then make test-readme; fi
+  - make test-readme
   - make ci
 cache: pip
 jobs:
   include:
     - stage: test
       script:
-        - |
-          if [[ "$TRAVIS_PYTHON_VERSION" != "2.6" ]] ; then make test-readme; fi
+        - make test-readme
         - make ci
     - stage: coverage
       python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ python:
   # - "3.7-dev"
   # - "pypy"  -- appears to hang
   # - "pypy3"
+matrix:
+  allow_failures:
+    - python: 3.7-dev
 # command to install dependencies
 install: "make"
 # command to run tests

--- a/3.0-HISTORY.rst
+++ b/3.0-HISTORY.rst
@@ -1,6 +1,8 @@
 3.0.0 (2017-xx-xx)
 ++++++++++++++++++
 
+- Support for Python 2.6 has been dropped.
+
 - Simplified logic for determining Content-Length and Transfer-Encoding.
   Requests will now avoid setting both headers on the same request, and
   raise an exception if this is done manually by a user.

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -128,7 +128,7 @@ Patches and Suggestions
 - Bryce Boe <bbzbryce@gmail.com> (`@bboe <https://github.com/bboe>`_)
 - Colin Dunklau <colin.dunklau@gmail.com> (`@cdunklau <https://github.com/cdunklau>`_)
 - Bob Carroll <bob.carroll@alum.rit.edu> (`@rcarz <https://github.com/rcarz>`_)
-- Hugo Osvaldo Barrera <hugo@osvaldobarrera.com.ar> (`@hobarrera <https://github.com/hobarrera>`_)
+- Hugo Osvaldo Barrera <hugo@barrera.io> (`@hobarrera <https://github.com/hobarrera>`_)
 - Łukasz Langa <lukasz@langa.pl>
 - Dave Shawley <daveshawley@gmail.com>
 - James Clarke (`@jam <https://github.com/jam>`_)

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Requests is ready for today's web.
 - ``.netrc`` Support
 - Chunked Requests
 
-Requests officially supports Python 2.6–2.7 & 3.3–3.7, and runs great on PyPy.
+Requests officially supports Python 2.7 & 3.3–3.7, and runs great on PyPy.
 
 Installation
 ------------

--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -54,7 +54,6 @@ Python 3 Support?
 Yes! Here's a list of Python platforms that are officially
 supported:
 
-* Python 2.6
 * Python 2.7
 * Python 3.3
 * Python 3.4
@@ -69,7 +68,7 @@ These errors occur when :ref:`SSL certificate verification <verification>`
 fails to match the certificate the server responds with to the hostname
 Requests thinks it's contacting. If you're certain the server's SSL setup is
 correct (for example, because you can visit the site with your browser) and
-you're using Python 2.6 or 2.7, a possible explanation is that you need
+you're using Python 2.7, a possible explanation is that you need
 Server-Name-Indication.
 
 `Server-Name-Indication`_, or SNI, is an official extension to SSL where the

--- a/docs/dev/todo.rst
+++ b/docs/dev/todo.rst
@@ -49,7 +49,6 @@ Runtime Environments
 
 Requests currently supports the following versions of Python:
 
-- Python 2.6
 - Python 2.7
 - Python 3.3
 - Python 3.4

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -104,7 +104,7 @@ Requests is ready for today's web.
 - Chunked Requests
 - ``.netrc`` Support
 
-Requests officially supports Python 2.6–2.7 & 3.3–3.7, and runs great on PyPy.
+Requests officially supports Python 2.7 & 3.3–3.7, and runs great on PyPy.
 
 
 The User Guide

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -100,12 +100,7 @@ from .exceptions import (
 
 # Set default logging handler to avoid "No handler found" warnings.
 import logging
-try:  # Python 2.7+
-    from logging import NullHandler
-except ImportError:
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
+from logging import NullHandler
 
 logging.getLogger(__name__).addHandler(NullHandler())
 

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -478,11 +478,10 @@ class HTTPAdapter(BaseAdapter):
 
                     # Receive the response from the server
                     try:
-                        # For Python 2.7+ versions, use buffering of HTTP
-                        # responses
+                        # For Python 2.7, use buffering of HTTP responses
                         r = low_conn.getresponse(buffering=True)
                     except TypeError:
-                        # For compatibility with Python 2.6 versions and back
+                        # For Python 3.3+ versions, this is the default
                         r = low_conn.getresponse()
 
                     resp = HTTPResponse.from_httplib(

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -187,8 +187,7 @@ class HTTPAdapter(BaseAdapter):
         self.init_poolmanager(pool_connections, pool_maxsize, block=pool_block)
 
     def __getstate__(self):
-        return dict((attr, getattr(self, attr, None)) for attr in
-                    self.__attrs__)
+        return {attr: getattr(self, attr, None) for attr in self.__attrs__}
 
     def __setstate__(self, state):
         # Can't handle by adding 'proxy_manager' to self.__attrs__ because

--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -440,20 +440,21 @@ def create_cookie(name, value, **kwargs):
     By default, the pair of `name` and `value` will be set for the domain ''
     and sent on every request (this is sometimes called a "supercookie").
     """
-    result = dict(
-        version=0,
-        name=name,
-        value=value,
-        port=None,
-        domain='',
-        path='/',
-        secure=False,
-        expires=None,
-        discard=True,
-        comment=None,
-        comment_url=None,
-        rest={'HttpOnly': None},
-        rfc2109=False,)
+    result = {
+        'version': 0,
+        'name': name,
+        'value': value,
+        'port': None,
+        'domain': '',
+        'path': '/',
+        'secure': False,
+        'expires': None,
+        'discard': True,
+        'comment': None,
+        'comment_url': None,
+        'rest': {'HttpOnly': None},
+        'rfc2109': False,
+    }
 
     badargs = set(kwargs) - set(result)
     if badargs:

--- a/requests/hooks.py
+++ b/requests/hooks.py
@@ -15,14 +15,14 @@ HOOKS = ['response']
 
 
 def default_hooks():
-    return dict((event, []) for event in HOOKS)
+    return {event: [] for event in HOOKS}
 
 # TODO: response is the only one
 
 
 def dispatch_hook(key, hooks, hook_data, **kwargs):
     """Dispatches a hook dictionary on a given piece of data."""
-    hooks = hooks or dict()
+    hooks = hooks or {}
     hooks = hooks.get(key)
     if hooks:
         if hasattr(hooks, '__call__'):

--- a/requests/models.py
+++ b/requests/models.py
@@ -653,10 +653,7 @@ class Response(object):
         if not self._content_consumed:
             self.content
 
-        return dict(
-            (attr, getattr(self, attr, None))
-            for attr in self.__attrs__
-        )
+        return {attr: getattr(self, attr, None) for attr in self.__attrs__}
 
     def __setstate__(self, state):
         for name, value in state.items():

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -736,7 +736,7 @@ class Session(SessionRedirectMixin):
             self.adapters[key] = self.adapters.pop(key)
 
     def __getstate__(self):
-        state = dict((attr, getattr(self, attr, None)) for attr in self.__attrs__)
+        state = {attr: getattr(self, attr, None) for attr in self.__attrs__}
         return state
 
     def __setstate__(self, state):

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -679,22 +679,8 @@ def should_bypass_proxies(url, no_proxy):
                     # to apply the proxies on this URL.
                     return True
 
-    # If the system proxy settings indicate that this URL should be bypassed,
-    # don't proxy.
-    # The proxy_bypass function is incredibly buggy on OS X in early versions
-    # of Python 2.6, so allow this call to fail. Only catch the specific
-    # exceptions we've seen, though: this call failing in other ways can reveal
-    # legitimate problems.
     with set_environ('no_proxy', no_proxy_arg):
-        try:
-            bypass = proxy_bypass(netloc)
-        except (TypeError, socket.gaierror):
-            bypass = False
-
-    if bypass:
-        return True
-
-    return False
+        return bool(proxy_bypass(netloc))
 
 
 def get_environ_proxies(url, no_proxy=None):

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
@@ -95,7 +95,6 @@ setup(
     extras_require={
         'security': ['pyOpenSSL>=0.14', 'cryptography>=1.3.4', 'idna>=2.0.0'],
         'socks': ['PySocks>=1.5.6, !=1.5.7'],
-        'socks:sys_platform == "win32" and (python_version == "2.7" or python_version == "2.6")': ['win_inet_pton'],
+        'socks:sys_platform == "win32" and python_version == "2.7"': ['win_inet_pton'],
     },
 )
-

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -933,7 +933,7 @@ class TestRequests:
 
     def test_urlencoded_get_query_multivalued_param(self, httpbin):
 
-        r = requests.get(httpbin('get'), params=dict(test=['foo', 'baz']))
+        r = requests.get(httpbin('get'), params={'test': ['foo', 'baz']})
         assert r.status_code == 200
         assert r.url == httpbin('get?test=foo&test=baz')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -566,7 +566,7 @@ def test_add_dict_to_cookiejar(cookiejar):
     cookiedict = {'test': 'cookies',
                   'good': 'cookies'}
     cj = add_dict_to_cookiejar(cookiejar, cookiedict)
-    cookies = dict((cookie.name, cookie.value) for cookie in cj)
+    cookies = {cookie.name: cookie.value for cookie in cj}
     assert cookiedict == cookies
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,py36
+envlist = py27,py33,py34,py35,py36
 
 [testenv]
 


### PR DESCRIPTION
Drop support for python2.6. Fixes #3928

Note that this targets the 3.0.0 branch, not master.