### PR TITLE
Add the pytest .cache/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ nosetests.xml
 junit-report.xml
 pylint.txt
 toy.py
+.cache/
 cover/
 build/
 docs/_build


### PR DESCRIPTION
For example, when a pytest run fails, it saves failure metadata to:
`.cache/v/cache/lastfailed`