### PR TITLE
Convert version compatibility checks to warnings

### DIFF
--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -115,3 +115,8 @@ class RequestsWarning(Warning):
 class FileModeWarning(RequestsWarning, DeprecationWarning):
     """A file was opened in text mode, but Requests determined its binary length."""
     pass
+
+
+class RequestsDependencyWarning(RequestsWarning):
+    """An imported dependency doesn't match the expected version range."""
+    pass


### PR DESCRIPTION
This patch will convert the dependency exceptions into warnings, preventing the forced halt while importing Requests. I condensed the message into a single response, but we can expand that out if needed. It just seemed like another place for updates to be forgotten.

I'd also like to test this function, but due to the requirements changing with each release, it's hard to write something that won't need to be updated in parallel. We could look at parsing the requirements out of `requires` but that seems less than ideal. If I'm being honest, I'm not crazy about expanding the code around this any more than we absolutely have to.