### PR TITLE
Fix help ssl check

### DIFF
--- a/requests/help.py
+++ b/requests/help.py
@@ -85,12 +85,16 @@ def info():
         'version': getattr(cryptography, '__version__', ''),
     }
 
+    # OPENSSL_VERSION_NUMBER doesn't exist in the Python 2.6 ssl module.
+    system_ssl = getattr(ssl, 'OPENSSL_VERSION_NUMBER', None)
+    system_ssl_info = {
+        'version': '%x' % system_ssl if system_ssl is not None else ''
+    }
+
     return {
         'platform': platform_info,
         'implementation': implementation_info,
-        'system_ssl': {
-            'version': '%x' % ssl.OPENSSL_VERSION_NUMBER,
-        },
+        'system_ssl': system_ssl_info,
         'using_pyopenssl': pyopenssl is not None,
         'pyOpenSSL': pyopenssl_info,
         'urllib3': urllib3_info,

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,0 +1,21 @@
+# -*- encoding: utf-8
+
+import sys
+
+import pytest
+
+from requests.help import info
+
+
+@pytest.mark.skipif(sys.version_info[:2] != (2,6), reason="Only run on Python 2.6")
+def test_system_ssl_py26():
+    """OPENSSL_VERSION_NUMBER isn't provided in Python 2.6, verify we don't
+    blow up in this case.
+    """
+    assert info()['system_ssl'] == {'version': ''}
+
+
+@pytest.mark.skipif(sys.version_info < (2,7), reason="Only run on Python 2.7+")
+def test_system_ssl():
+    """Verify we're actually setting system_ssl when it should be available."""
+    assert info()['system_ssl']['version'] != ''


### PR DESCRIPTION
This will resolve the test failures discovered in #4182. We were retrieving the `OPENSSL_VERSION_NUMBER` from the system `ssl` module in all cases before now. This attribute doesn't exist in Python 2.6 causing new tests for the `info()` method to fail. This patch will return an empty value for Python 2.6 since we don't seem to have a way to reliably check the openssl version.

@Lukasa @sigmavirus24, I've pushed this branch up to the requests repo directly, so feel free to chop this up or do anything you feel is necessary to get #4182 moving. I don't know that the provided test is especially useful, but it does show that the fix here works.