### PR TITLE
Add requirements.txt to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include README.rst LICENSE NOTICE HISTORY.rst pytest.ini
+include README.rst LICENSE NOTICE HISTORY.rst pytest.ini requirements.txt
 recursive-include tests *.py


### PR DESCRIPTION
Three tests [1] rely on `requirements.txt` being available. If the file is not present, the following error is observed in those tests:

```
  >       with open('requirements.txt') as f:
  E       IOError: [Errno 2] No such file or directory: 'requirements.txt'
```

The latest (2.18.1) source distribution on PyPI does not include requirements.txt, which precludes successfully passing the tests.

This change adds the required file to the source distribution. An alternative is to use a different file already included in the sdist.

Additionally, skipping tests if a required resource (library, file, etc) is not available would be a user experience improvement.

[1] test_POSTBIN_GET_POST_FILES, test_POSTBIN_GET_POST_FILES_WITH_DATA, test_conflicting_post_params,
