### PR TITLE
compat.py uses try/except to prevent linter errors

### DIFF
--- a/requests/compat.py
+++ b/requests/compat.py
@@ -32,6 +32,21 @@ except (ImportError, SyntaxError):
     # because of u'...' Unicode literals.
     import json
 
+try:
+    integer_types = (int, long)  # Python 2
+    numeric_types = (int, long, float)
+except NameError:
+    integer_types = (int, )      # Python 3
+    numeric_types = (int, float)
+    
+builtin_str = str
+try:
+    basestring                   # Python 2
+    bytes = str
+    str = unicode
+except NameError:
+    basestring = (str, bytes)    # Python 3
+
 # ---------
 # Specifics
 # ---------
@@ -45,16 +60,7 @@ if is_py2:
     import cookielib
     from Cookie import Morsel
     from StringIO import StringIO
-
     from urllib3.packages.ordered_dict import OrderedDict
-
-    builtin_str = str
-    bytes = str
-    str = unicode
-    basestring = basestring
-    numeric_types = (int, long, float)
-    integer_types = (int, long)
-
 elif is_py3:
     from urllib.parse import urlparse, urlunparse, urljoin, urlsplit, urlencode, quote, unquote, quote_plus, unquote_plus, urldefrag
     from urllib.request import parse_http_list, getproxies, proxy_bypass, proxy_bypass_environment, getproxies_environment
@@ -62,10 +68,3 @@ elif is_py3:
     from http.cookies import Morsel
     from io import StringIO
     from collections import OrderedDict
-
-    builtin_str = str
-    str = str
-    bytes = bytes
-    basestring = (str, bytes)
-    numeric_types = (int, float)
-    integer_types = (int,)


### PR DESCRIPTION
flake8 testing of https://github.com/requests/requests on Python 3.6.2

$ __time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./requests/compat.py:53:11: F821 undefined name 'unicode'
    str = unicode
          ^

./requests/compat.py:54:18: F821 undefined name 'basestring'
    basestring = basestring
                 ^

./requests/compat.py:55:27: F821 undefined name 'long'
    numeric_types = (int, long, float)
                          ^

./requests/compat.py:56:27: F821 undefined name 'long'
    integer_types = (int, long)
                          ^

./requests/models.py:357:19: F821 undefined name 'unicode'
            url = unicode(url) if is_py2 else str(url)
                  ^
```