### PR TITLE
Use 'prefix' instead of 'key' in session docstring

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -704,7 +704,7 @@ class Session(SessionRedirectMixin):
     def mount(self, prefix, adapter):
         """Registers a connection adapter to a prefix.
 
-        Adapters are sorted in descending order by key length.
+        Adapters are sorted in descending order by prefix length.
         """
         self.adapters[prefix] = adapter
         keys_to_move = [k for k in self.adapters if len(k) < len(prefix)]


### PR DESCRIPTION
This commit makes [the API docs](http://docs.python-requests.org/en/master/api/#requests.Session.mount) more clear. The 'key' is an implementation detail.