### PR TITLE
Correct urllib3 compatibility comment

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -57,7 +57,7 @@ def check_compatibility(urllib3_version, chardet_version):
     # Check urllib3 for compatibility.
     major, minor, patch = urllib3_version  # noqa: F811
     major, minor, patch = int(major), int(minor), int(patch)
-    # urllib3 >= 1.21.1, < 1.22
+    # urllib3 >= 1.21.1, <= 1.22
     assert major == 1
     assert minor >= 21
     assert minor <= 22


### PR DESCRIPTION
So that it's in line with the code. 

I saw the warning raised recently and had to dive into the code for exact compatibility, but I stopped after reading the comment rather than the code. 

Maybe a better solution would be to surface the supported versions in the warning? However, I see it was changed recently in https://github.com/requests/requests/pull/4144/, any specific reason for removing that?