### PR TITLE
some docs on request redirect detection

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -97,6 +97,12 @@ class SessionRedirectMixin(object):
 
     def get_redirect_target(self, resp):
         """Receives a Response. Returns a redirect URI or ``None``"""
+        # Due to the nature of how requests processes redirects this method will
+        # be called at least once upon the original response and at least twice
+        # on each subsequent redirect response (if any).
+        # If a custom mixin is used to handle this logic, it may be advantageous
+        # to cache the redirect location onto the response object as a private
+        # attribute.
         if resp.is_redirect:
             location = resp.headers['location']
             # Currently the underlying http module on py3 decode headers


### PR DESCRIPTION
This is just a small docstring that I wanted to suggest for inclusion. I should have offered it in my earlier commit.

The purpose of the docstring: we had some unit tests to ensure that `get_redirect_target` was being called the appropriate number of times. They broke because I calculated the number incorrectly.  It took a while to re-familiarize myself with the code and figure out what was going on.