### PR TITLE
remove legacy super() call

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -586,8 +586,6 @@ class Response(object):
     ]
 
     def __init__(self):
-        super(Response, self).__init__()
-
         self._content = False
         self._content_consumed = False
         self._next = None


### PR DESCRIPTION
This does not seem to be necessary anymore since there is no longer a `BaseResponse` object from which `Response` inherits.