### PR TITLE
Adding header name to exception

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ dev
 +++
 
 **Improvements**
+- Error messages for invalid headers now include the header name for easier debugging
 
 **Bugfixes**
 

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -868,8 +868,8 @@ def check_header_validity(header):
         if not pat.match(value):
             raise InvalidHeader("Invalid return character or leading space in header: %s" % name)
     except TypeError:
-        raise InvalidHeader("Header value %s must be of type str or bytes, "
-                            "not %s" % (value, type(value)))
+        raise InvalidHeader("Header %s value %s must be of type str or bytes, "
+                            "not %s" % (name, value, type(value)))
 
 
 def urldefragauth(url):

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -868,7 +868,7 @@ def check_header_validity(header):
         if not pat.match(value):
             raise InvalidHeader("Invalid return character or leading space in header: %s" % name)
     except TypeError:
-        raise InvalidHeader("Value for header {%s:%s} must be of type str or " 
+        raise InvalidHeader("Value for header {%s:%s} must be of type str or "
                             "bytes, not %s" % (name, value, type(value)))
 
 

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -868,8 +868,8 @@ def check_header_validity(header):
         if not pat.match(value):
             raise InvalidHeader("Invalid return character or leading space in header: %s" % name)
     except TypeError:
-        raise InvalidHeader("Header %s value %s must be of type str or bytes, "
-                            "not %s" % (name, value, type(value)))
+        raise InvalidHeader("Value for header {%s:%s} must be of type str or " 
+                            "bytes, not %s" % (name, value, type(value)))
 
 
 def urldefragauth(url):

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -868,7 +868,7 @@ def check_header_validity(header):
         if not pat.match(value):
             raise InvalidHeader("Invalid return character or leading space in header: %s" % name)
     except TypeError:
-        raise InvalidHeader("Value for header {%s:%s} must be of type str or "
+        raise InvalidHeader("Value for header {%s: %s} must be of type str or "
                             "bytes, not %s" % (name, value, type(value)))
 
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1401,14 +1401,17 @@ class TestRequests:
         headers_list = {'baz': ['foo', 'bar']}
 
         # Test for int
-        with pytest.raises(InvalidHeader):
+        with pytest.raises(InvalidHeader) as excinfo:
             r = requests.get(httpbin('get'), headers=headers_int)
+        assert 'foo' in str(excinfo.value)
         # Test for dict
-        with pytest.raises(InvalidHeader):
+        with pytest.raises(InvalidHeader) as excinfo:
             r = requests.get(httpbin('get'), headers=headers_dict)
+        assert 'bar' in str(excinfo.value)
         # Test for list
-        with pytest.raises(InvalidHeader):
+        with pytest.raises(InvalidHeader) as excinfo:
             r = requests.get(httpbin('get'), headers=headers_list)
+        assert 'baz' in str(excinfo.value)
 
     def test_header_no_return_chars(self, httpbin):
         """Ensure that a header containing return character sequences raise an


### PR DESCRIPTION
Adds the name of the header to the invalid header exception raised on TypeError.

Fixes #4239 