### PR TITLE
Fix parse_header_links on empty header

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,8 @@ dev
 
 **Bugfixes**
 
+- Parsing empty ``Link`` headers with ``parse_header_links()`` no longer return one bogus entry
+
 2.18.4 (2017-08-15)
 +++++++++++++++++++
 

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -743,7 +743,7 @@ def default_headers():
 
 
 def parse_header_links(value):
-    """Return a dict of parsed link headers proxies.
+    """Return a list of parsed link headers proxies.
 
     i.e. Link: <http:/.../front.jpeg>; rel=front; type="image/jpeg",<http://.../back.jpeg>; rel=back;type="image/jpeg"
 
@@ -753,6 +753,10 @@ def parse_header_links(value):
     links = []
 
     replace_chars = ' \'"'
+
+    value = value.strip(replace_chars)
+    if not value:
+        return links
 
     for val in re.split(', *<', value):
         try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -498,6 +498,10 @@ def test_iter_slices(value, length):
                 {'url': 'http://.../back.jpeg'}
             ]
         ),
+        (
+            '',
+            []
+        ),
     ))
 def test_parse_header_links(value, expected):
     assert parse_header_links(value) == expected


### PR DESCRIPTION
When receiving an empty `Link:` header, one bogus entry was returned anyway. This breaks some applications.

I agree that web servers shouldn't be sending those but they do so here we are. Also fixes docstring with proper return type.

Fixes https://github.com/halcy/Mastodon.py/issues/74