### PR TITLE
Pin to httpbin 0.5.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ docutils
 flake8
 tox
 detox
+httpbin==0.5.0


### PR DESCRIPTION
The release of httpbin 0.6.0 seems to have broken pytest-httpbin in a surprising way. We want to pin that version out, and probably also alert @kevin1024 about the problem.

Resolves #4259.