### PR TITLE
[do not merge] Try to fix hanging tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -e .[socks]
 pytest>=2.8.0
 codecov
-pytest-httpbin==0.0.7
+pytest-httpbin
 pytest-mock
 pytest-cov
 pytest-xdist
@@ -14,4 +14,4 @@ docutils
 flake8
 tox
 detox
-httpbin==0.5.0
+httpbin


### PR DESCRIPTION
The tests are hanging sometimes, see #4259 and #4261.  I wonder if it would work to unpin both packages since I think I fixed a bug with pytest-httpbin hanging awhile back.