### PR TITLE
REQUESTS_DONT_USE_PYOPENSSL

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -39,6 +39,7 @@ is at <http://python-requests.org>.
 :copyright: (c) 2017 by Kenneth Reitz.
 :license: Apache 2.0, see LICENSE for more details.
 """
+import os
 
 import urllib3
 import chardet
@@ -81,8 +82,9 @@ except (AssertionError, ValueError):
 
 # Attempt to enable urllib3's SNI support, if possible
 try:
-    from urllib3.contrib import pyopenssl
-    pyopenssl.inject_into_urllib3()
+    if not 'REQUESTS_DONT_USE_PYOPENSSL' in os.environ:
+        from urllib3.contrib import pyopenssl
+        pyopenssl.inject_into_urllib3()
 except ImportError:
     pass
 

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -82,7 +82,7 @@ except (AssertionError, ValueError):
 
 # Attempt to enable urllib3's SNI support, if possible
 try:
-    if not 'REQUESTS_DONT_USE_PYOPENSSL' in os.environ:
+    if 'REQUESTS_DONT_USE_PYOPENSSL' not in os.environ:
         from urllib3.contrib import pyopenssl
         pyopenssl.inject_into_urllib3()
 except ImportError:


### PR DESCRIPTION
Basically, a lot of people are installing pipenv in envs which also have `requests[security]` installed, which slows down the CLI tool quite a bit (at import time). 

This patch would allow pipenv to disable the upgrade within itself, speeding up the experience for those users. 

/cc @Lukasa @alex 