### PR TITLE
Fix the invalid restructured text in HISTORY file

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -52,8 +52,8 @@ dev
 
 **Bugfixes**
 
-- Fix an error in the packaging whereby the *.whl contained incorrect data that
-  regressed the fix in v2.17.3.
+- Fix an error in the packaging whereby the ``*.whl`` contained incorrect data
+  that regressed the fix in v2.17.3.
 
 2.18.0 (2017-06-14)
 +++++++++++++++++++


### PR DESCRIPTION
This was breaking the display of our long_description on PyPI.