### PR TITLE
Remove redundant Python 2.6 stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  # - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"
@@ -13,19 +12,15 @@ python:
 install: "make"
 # command to run tests
 script:
-  - |
-    if [[ "$TRAVIS_PYTHON_VERSION" != "2.6" ]] ; then make test-readme; fi
+  - make test-readme
   - make ci
 cache: pip
 jobs:
   include:
     - stage: test
       script:
-        - |
-          if [[ "$TRAVIS_PYTHON_VERSION" != "2.6" ]] ; then make test-readme; fi
+        - make test-readme
         - make ci
     - stage: coverage
       python: 3.6
       script: codecov
-
-

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Requests is ready for today's web.
 - ``.netrc`` Support
 - Chunked Requests
 
-Requests officially supports Python 2.6–2.7 & 3.3–3.7, and runs great on PyPy.
+Requests officially supports Python 2.7 & 3.4–3.7, and runs great on PyPy.
 
 Installation
 ------------

--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -70,7 +70,7 @@ These errors occur when :ref:`SSL certificate verification <verification>`
 fails to match the certificate the server responds with to the hostname
 Requests thinks it's contacting. If you're certain the server's SSL setup is
 correct (for example, because you can visit the site with your browser) and
-you're using Python 2.6 or 2.7, a possible explanation is that you need
+you're using Python 2.7, a possible explanation is that you need
 Server-Name-Indication.
 
 `Server-Name-Indication`_, or SNI, is an official extension to SSL where the

--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -56,11 +56,11 @@ Python 3 Support?
 Yes! Here's a list of Python platforms that are officially
 supported:
 
-* Python 2.6
 * Python 2.7
 * Python 3.4
 * Python 3.5
 * Python 3.6
+* Python 3.7
 * PyPy
 
 What are "hostname doesn't match" errors?

--- a/docs/dev/todo.rst
+++ b/docs/dev/todo.rst
@@ -51,11 +51,11 @@ Runtime Environments
 
 Requests currently supports the following versions of Python:
 
-- Python 2.6
 - Python 2.7
 - Python 3.4
 - Python 3.5
 - Python 3.6
+- Python 3.7
 - PyPy
 
 Google AppEngine is not officially supported although support is available

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,8 +30,8 @@ consumption.
 
 .. note:: The use of **Python 3** is *highly* preferred over Python 2. Consider upgrading your applications and infrastructure if you find yourself *still* using Python 2 in production today. If you are using Python 3, congratulations — you are indeed a person of excellent taste.
   —*Kenneth Reitz*
-  
-  
+
+
 -------------------
 
 **Behold, the power of Requests**::
@@ -104,7 +104,7 @@ Requests is ready for today's web.
 - Chunked Requests
 - ``.netrc`` Support
 
-Requests officially supports Python 2.6–2.7 & 3.4–3.7, and runs great on PyPy.
+Requests officially supports Python 2.7 & 3.4–3.7, and runs great on PyPy.
 
 
 The User Guide

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -108,14 +108,8 @@ from .exceptions import (
 
 # Set default logging handler to avoid "No handler found" warnings.
 import logging
-try:  # Python 2.7+
-    from logging import NullHandler
-except ImportError:
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
 
-logging.getLogger(__name__).addHandler(NullHandler())
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 # FileModeWarnings go off per the default.
 warnings.simplefilter('default', FileModeWarning, append=True)

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -465,8 +465,6 @@ class HTTPAdapter(BaseAdapter):
                     low_conn.send(b'0\r\n\r\n')
 
                     # Receive the response from the server
-                    # For Python 2.7+ versions, use buffering of HTTP
-                    # responses
                     r = low_conn.getresponse(buffering=True)
 
                     resp = HTTPResponse.from_httplib(

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -465,7 +465,11 @@ class HTTPAdapter(BaseAdapter):
                     low_conn.send(b'0\r\n\r\n')
 
                     # Receive the response from the server
-                    r = low_conn.getresponse(buffering=True)
+                    try:
+                        r = low_conn.getresponse(buffering=True)
+                    except TypeError:
+                        # For compatibility with Python 3.6 versions and up
+                        r = low_conn.getresponse()
 
                     resp = HTTPResponse.from_httplib(
                         r,

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -465,13 +465,9 @@ class HTTPAdapter(BaseAdapter):
                     low_conn.send(b'0\r\n\r\n')
 
                     # Receive the response from the server
-                    try:
-                        # For Python 2.7+ versions, use buffering of HTTP
-                        # responses
-                        r = low_conn.getresponse(buffering=True)
-                    except TypeError:
-                        # For compatibility with Python 2.6 versions and back
-                        r = low_conn.getresponse()
+                    # For Python 2.7+ versions, use buffering of HTTP
+                    # responses
+                    r = low_conn.getresponse(buffering=True)
 
                     resp = HTTPResponse.from_httplib(
                         r,

--- a/requests/compat.py
+++ b/requests/compat.py
@@ -44,8 +44,6 @@ if is_py2:
     from Cookie import Morsel
     from StringIO import StringIO
 
-    from urllib3.packages.ordered_dict import OrderedDict
-
     builtin_str = str
     bytes = str
     str = unicode
@@ -59,7 +57,6 @@ elif is_py3:
     from http import cookiejar as cookielib
     from http.cookies import Morsel
     from io import StringIO
-    from collections import OrderedDict
 
     builtin_str = str
     str = str

--- a/requests/help.py
+++ b/requests/help.py
@@ -89,12 +89,6 @@ def info():
         'version': getattr(idna, '__version__', ''),
     }
 
-    # OPENSSL_VERSION_NUMBER doesn't exist in the Python 2.6 ssl module.
-    system_ssl = getattr(ssl, 'OPENSSL_VERSION_NUMBER', None)
-    system_ssl_info = {
-        'version': '%x' % system_ssl if system_ssl is not None else ''
-    }
-
     return {
         'platform': platform_info,
         'implementation': implementation_info,

--- a/requests/help.py
+++ b/requests/help.py
@@ -89,6 +89,10 @@ def info():
         'version': getattr(idna, '__version__', ''),
     }
 
+    system_ssl_info = {
+        'version': getattr(ssl, 'OPENSSL_VERSION_NUMBER', '')
+    }
+
     return {
         'platform': platform_info,
         'implementation': implementation_info,

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -10,11 +10,11 @@ requests (cookies, auth, proxies).
 import os
 import platform
 import time
-from collections import Mapping
+from collections import OrderedDict, Mapping
 from datetime import timedelta
 
 from .auth import _basic_auth_str
-from .compat import cookielib, is_py3, OrderedDict, urljoin, urlparse
+from .compat import cookielib, is_py3, urljoin, urlparse
 from .cookies import (
     cookiejar_from_dict, extract_cookies_to_jar, RequestsCookieJar, merge_cookies)
 from .models import Request, PreparedRequest, DEFAULT_REDIRECT_LIMIT

--- a/requests/structures.py
+++ b/requests/structures.py
@@ -9,8 +9,6 @@ Data structures that power Requests.
 
 import collections
 
-from .compat import OrderedDict
-
 
 class CaseInsensitiveDict(collections.MutableMapping):
     """A case-insensitive ``dict``-like object.
@@ -40,7 +38,7 @@ class CaseInsensitiveDict(collections.MutableMapping):
     """
 
     def __init__(self, data=None, **kwargs):
-        self._store = OrderedDict()
+        self._store = collections.OrderedDict()
         if data is None:
             data = {}
         self.update(data, **kwargs)

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -26,7 +26,7 @@ from . import certs
 from ._internal_utils import to_native_string
 from .compat import parse_http_list as _parse_list_header
 from .compat import (
-    quote, urlparse, bytes, str, OrderedDict, unquote, getproxies,
+    quote, urlparse, bytes, str, unquote, getproxies,
     proxy_bypass, urlunparse, basestring, integer_types, is_py3,
     proxy_bypass_environment, getproxies_environment)
 from .cookies import cookiejar_from_dict
@@ -238,7 +238,7 @@ def from_key_val_list(value):
     if isinstance(value, (str, bytes, bool, int)):
         raise ValueError('cannot encode objects that are not 2-tuples')
 
-    return OrderedDict(value)
+    return collections.OrderedDict(value)
 
 
 def to_key_val_list(value):
@@ -667,15 +667,8 @@ def should_bypass_proxies(url, no_proxy):
 
     # If the system proxy settings indicate that this URL should be bypassed,
     # don't proxy.
-    # The proxy_bypass function is incredibly buggy on OS X in early versions
-    # of Python 2.6, so allow this call to fail. Only catch the specific
-    # exceptions we've seen, though: this call failing in other ways can reveal
-    # legitimate problems.
     with set_environ('no_proxy', no_proxy_arg):
-        try:
-            bypass = proxy_bypass(netloc)
-        except (TypeError, socket.gaierror):
-            bypass = False
+        bypass = proxy_bypass(netloc)
 
     if bypass:
         return True

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,6 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     extras_require={
         'security': ['pyOpenSSL>=0.14', 'cryptography>=1.3.4', 'idna>=2.0.0'],
         'socks': ['PySocks>=1.5.6, !=1.5.7'],
-        'socks:sys_platform == "win32" and (python_version == "2.7" or python_version == "2.6")': ['win_inet_pton'],
+        'socks:sys_platform == "win32" and (python_version == "2.7")': ['win_inet_pton'],
     },
 )
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -7,15 +7,6 @@ import pytest
 from requests.help import info
 
 
-@pytest.mark.skipif(sys.version_info[:2] != (2,6), reason="Only run on Python 2.6")
-def test_system_ssl_py26():
-    """OPENSSL_VERSION_NUMBER isn't provided in Python 2.6, verify we don't
-    blow up in this case.
-    """
-    assert info()['system_ssl'] == {'version': ''}
-
-
-@pytest.mark.skipif(sys.version_info < (2,7), reason="Only run on Python 2.7+")
 def test_system_ssl():
     """Verify we're actually setting system_ssl when it should be available."""
     assert info()['system_ssl']['version'] != ''

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -17,7 +17,7 @@ from requests.adapters import HTTPAdapter
 from requests.auth import HTTPDigestAuth, _basic_auth_str
 from requests.compat import (
     Morsel, cookielib, getproxies, str, urlparse,
-    builtin_str, OrderedDict)
+    builtin_str)
 from requests.cookies import (
     cookiejar_from_dict, morsel_to_cookie)
 from requests.exceptions import (
@@ -126,7 +126,8 @@ class TestRequests:
         assert request.url == expected
 
     def test_params_original_order_is_preserved_by_default(self):
-        param_ordered_dict = OrderedDict((('z', 1), ('a', 1), ('k', 1), ('d', 1)))
+        param_ordered_dict = collections.OrderedDict(
+            (('z', 1), ('a', 1), ('k', 1), ('d', 1)))
         session = requests.Session()
         request = requests.Request('GET', 'http://example.com/', params=param_ordered_dict)
         prep = session.prepare_request(request)
@@ -434,11 +435,11 @@ class TestRequests:
     def test_headers_preserve_order(self, httpbin):
         """Preserve order when headers provided as OrderedDict."""
         ses = requests.Session()
-        ses.headers = OrderedDict()
+        ses.headers = collections.OrderedDict()
         ses.headers['Accept-Encoding'] = 'identity'
         ses.headers['First'] = '1'
         ses.headers['Second'] = '2'
-        headers = OrderedDict([('Third', '3'), ('Fourth', '4')])
+        headers = collections.OrderedDict([('Third', '3'), ('Fourth', '4')])
         headers['Fifth'] = '5'
         headers['Second'] = '222'
         req = requests.Request('GET', httpbin('get'), headers=headers)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,py36
+envlist = py27,py33,py34,py35,py36
 
 [testenv]
 


### PR DESCRIPTION
Python 2.6 support was dropped in https://github.com/requests/requests/pull/4118.

This removes some other redundant 2.6 code. 

Also mention Python 3.7 as officially supported, to reflect the README.
