### PR TITLE
removed python2 unicode literals from documentation examples

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,9 +44,9 @@ consumption.
     >>> r.encoding
     'utf-8'
     >>> r.text
-    u'{"type":"User"...'
+    '{"type":"User"...'
     >>> r.json()
-    {u'private_gists': 419, u'total_private_repos': 77, ...}
+    {'private_gists': 419, 'total_private_repos': 77, ...}
 
 See `similar code, sans Requests <https://gist.github.com/973705>`_.
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -679,12 +679,12 @@ So, GitHub returns JSON. That's great, we can use the :meth:`r.json
     >>> commit_data = r.json()
 
     >>> print(commit_data.keys())
-    [u'committer', u'author', u'url', u'tree', u'sha', u'parents', u'message']
+    ['committer', 'author', 'url', 'tree', 'sha', 'parents', 'message']
 
-    >>> print(commit_data[u'committer'])
-    {u'date': u'2012-05-10T11:10:50-07:00', u'email': u'me@kennethreitz.com', u'name': u'Kenneth Reitz'}
+    >>> print(commit_data['committer'])
+    {'date': '2012-05-10T11:10:50-07:00', 'email': 'me@kennethreitz.com', 'name': 'Kenneth Reitz'}
 
-    >>> print(commit_data[u'message'])
+    >>> print(commit_data['message'])
     makin' history
 
 So far, so simple. Well, let's investigate the GitHub API a little bit. Now,
@@ -727,26 +727,26 @@ this issue already exists, we will use it as an example. Let's start by getting 
 
     >>> issue = json.loads(r.text)
 
-    >>> print(issue[u'title'])
+    >>> print(issue['title'])
     Feature any http verb in docs
 
-    >>> print(issue[u'comments'])
+    >>> print(issue['comments'])
     3
 
 Cool, we have three comments. Let's take a look at the last of them.
 
 ::
 
-    >>> r = requests.get(r.url + u'/comments')
+    >>> r = requests.get(r.url + '/comments')
     >>> r.status_code
     200
 
     >>> comments = r.json()
 
     >>> print(comments[0].keys())
-    [u'body', u'url', u'created_at', u'updated_at', u'user', u'id']
+    ['body', 'url', 'created_at', 'updated_at', 'user', 'id']
 
-    >>> print(comments[2][u'body'])
+    >>> print(comments[2]['body'])
     Probably in the "advanced" section
 
 Well, that seems like a silly place. Let's post a comment telling the poster
@@ -754,7 +754,7 @@ that he's silly. Who is the poster, anyway?
 
 ::
 
-    >>> print(comments[2][u'user'][u'login'])
+    >>> print(comments[2]['user']['login'])
     kennethreitz
 
 OK, so let's tell this Kenneth guy that we think this example should go in the
@@ -784,7 +784,7 @@ the very common Basic Auth.
     201
 
     >>> content = r.json()
-    >>> print(content[u'body'])
+    >>> print(content['body'])
     Sounds great! I'll get right on it.
 
 Brilliant. Oh, wait, no! I meant to add that it would take me a while, because

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -93,7 +93,7 @@ again::
 
     >>> r = requests.get('https://api.github.com/events')
     >>> r.text
-    u'[{"repository":{"open_issues":0,"url":"https://github.com/...
+    '[{"repository":{"open_issues":0,"url":"https://github.com/...
 
 Requests will automatically decode content from the server. Most unicode
 charsets are seamlessly decoded.
@@ -148,7 +148,7 @@ There's also a builtin JSON decoder, in case you're dealing with JSON data::
 
     >>> r = requests.get('https://api.github.com/events')
     >>> r.json()
-    [{u'repository': {u'open_issues': 0, u'url': 'https://github.com/...
+    [{'repository': {'open_issues': 0, 'url': 'https://github.com/...
 
 In case the JSON decoding fails, ``r.json()`` raises an exception. For example, if
 the response gets a 204 (No Content), or if the response contains invalid JSON,


### PR DESCRIPTION
The documentation has a bunch of examples showing unicode literals in Python 2's `u'foo'` syntax, including one in the front page right below the note encouraging users to switch to Python 3.