### PR TITLE
Remove redundant Python 2.6 stuff

### DIFF
--- a/3.0-HISTORY.rst
+++ b/3.0-HISTORY.rst
@@ -3,6 +3,9 @@
 
 - Support for Python 2.6 has been dropped.
 
+  - The ``OrderedDict`` import no longer exists in compat.py because it is part
+    of ``collections`` in Python 2.7 and newer.
+
 - Simplified logic for determining Content-Length and Transfer-Encoding.
   Requests will now avoid setting both headers on the same request, and
   raise an exception if this is done manually by a user.

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -182,3 +182,4 @@ Patches and Suggestions
 - Ed Morley (`@edmorley <https://github.com/edmorley>`_)
 - Matt Liu <liumatt@gmail.com> (`@mlcrazy <https://github.com/mlcrazy>`_)
 - Taylor Hoff <primdevs@protonmail.com> (`@PrimordialHelios <https://github.com/PrimordialHelios>`_)
+- Hugo van Kemenade (`@hugovk <https://github.com/hugovk>`_)

--- a/requests/compat.py
+++ b/requests/compat.py
@@ -39,8 +39,6 @@ if is_py2:
     from Cookie import Morsel
     from StringIO import StringIO
 
-    from urllib3.packages.ordered_dict import OrderedDict
-
     builtin_str = str
     bytes = str
     str = unicode
@@ -54,7 +52,6 @@ elif is_py3:
     from http import cookiejar as cookielib
     from http.cookies import Morsel
     from io import StringIO
-    from collections import OrderedDict
 
     builtin_str = str
     str = str

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -10,11 +10,11 @@ requests (cookies, auth, proxies).
 import os
 import platform
 import time
-from collections import Mapping
+from collections import Mapping, OrderedDict
 from datetime import timedelta
 
 from .auth import _basic_auth_str
-from .compat import cookielib, OrderedDict, urljoin, urlparse, is_py3, str
+from .compat import cookielib, urljoin, urlparse, is_py3, str
 from .cookies import (
     cookiejar_from_dict, extract_cookies_to_jar, RequestsCookieJar,
     merge_cookies, _copy_cookie_jar)

--- a/requests/structures.py
+++ b/requests/structures.py
@@ -9,8 +9,6 @@ Data structures that power Requests.
 
 import collections
 
-from .compat import OrderedDict
-
 
 class CaseInsensitiveDict(collections.MutableMapping):
     """A case-insensitive ``dict``-like object.
@@ -40,7 +38,7 @@ class CaseInsensitiveDict(collections.MutableMapping):
     """
 
     def __init__(self, data=None, **kwargs):
-        self._store = OrderedDict()
+        self._store = collections.OrderedDict()
         if data is None:
             data = {}
         self.update(data, **kwargs)

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -26,7 +26,7 @@ from . import certs
 from ._internal_utils import to_native_string
 from .compat import parse_http_list as _parse_list_header
 from .compat import (
-    quote, urlparse, bytes, str, OrderedDict, unquote, getproxies,
+    quote, urlparse, bytes, str, unquote, getproxies,
     proxy_bypass, urlunparse, basestring, integer_types, is_py2, is_py3,
     proxy_bypass_environment, getproxies_environment)
 from .cookies import cookiejar_from_dict
@@ -224,11 +224,11 @@ def from_key_val_list(value):
     ::
 
         >>> from_key_val_list([('key', 'val')])
-        OrderedDict([('key', 'val')])
+        collections.OrderedDict([('key', 'val')])
         >>> from_key_val_list('string')
         ValueError: need more than 1 value to unpack
         >>> from_key_val_list({'key': 'val'})
-        OrderedDict([('key', 'val')])
+        collections.OrderedDict([('key', 'val')])
 
     :rtype: OrderedDict
     """
@@ -238,7 +238,7 @@ def from_key_val_list(value):
     if isinstance(value, (str, bytes, bool, int)):
         raise ValueError('cannot encode objects that are not 2-tuples')
 
-    return OrderedDict(value)
+    return collections.OrderedDict(value)
 
 
 def to_key_val_list(value):

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -224,11 +224,11 @@ def from_key_val_list(value):
     ::
 
         >>> from_key_val_list([('key', 'val')])
-        collections.OrderedDict([('key', 'val')])
+        OrderedDict([('key', 'val')])
         >>> from_key_val_list('string')
         ValueError: need more than 1 value to unpack
         >>> from_key_val_list({'key': 'val'})
-        collections.OrderedDict([('key', 'val')])
+        OrderedDict([('key', 'val')])
 
     :rtype: OrderedDict
     """

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -18,7 +18,7 @@ from requests.adapters import HTTPAdapter
 from requests.auth import HTTPDigestAuth, _basic_auth_str
 from requests.compat import (
     Morsel, cookielib, getproxies, str, urlparse,
-    builtin_str, OrderedDict)
+    builtin_str)
 from requests.cookies import (
     cookiejar_from_dict, morsel_to_cookie)
 from requests.exceptions import (
@@ -144,7 +144,8 @@ class TestRequests:
         assert request.url == expected
 
     def test_params_original_order_is_preserved_by_default(self):
-        param_ordered_dict = OrderedDict((('z', 1), ('a', 1), ('k', 1), ('d', 1)))
+        param_ordered_dict = collections.OrderedDict(
+            (('z', 1), ('a', 1), ('k', 1), ('d', 1)))
         session = requests.Session()
         request = requests.Request('GET', 'http://example.com/', params=param_ordered_dict)
         prep = session.prepare_request(request)
@@ -539,11 +540,11 @@ class TestRequests:
     def test_headers_preserve_order(self, httpbin):
         """Preserve order when headers provided as OrderedDict."""
         ses = requests.Session()
-        ses.headers = OrderedDict()
+        ses.headers = collections.OrderedDict()
         ses.headers['Accept-Encoding'] = 'identity'
         ses.headers['First'] = '1'
         ses.headers['Second'] = '2'
-        headers = OrderedDict([('Third', '3'), ('Fourth', '4')])
+        headers = collections.OrderedDict([('Third', '3'), ('Fourth', '4')])
         headers['Fifth'] = '5'
         headers['Second'] = '222'
         req = requests.Request('GET', httpbin('get'), headers=headers)
@@ -2103,7 +2104,7 @@ class TestRequests:
         """Ensure that if a user manually sets a content length header, when
         the data is chunked, that an InvalidHeader error is raised.
         """
-        data = (i for i in [b'a', b'b', b'c']) 
+        data = (i for i in [b'a', b'b', b'c'])
         url = httpbin('post')
         with pytest.raises(InvalidHeader):
             r = requests.post(url, data=data, headers={'Content-Length': 'foo'})


### PR DESCRIPTION
Same as https://github.com/requests/requests/pull/4326 but for the proposed/3.0.0 branch.

The good news is nearly everything was already in this branch from https://github.com/requests/requests/pull/4118, except for tidying up some OrderedDict compat stuff.

Also, pytest>=3.0.0 is required for the Python 3.3 build, otherwise:
```
py.test -n 8 --boxed --junitxml=report.xml
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.3.6/bin/py.test", line 11, in <module>
    sys.exit(main())
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/_pytest/config.py", line 39, in main
    config = _prepareconfig(args, plugins)
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/_pytest/config.py", line 118, in _prepareconfig
    pluginmanager=pluginmanager, args=args)
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/_pytest/vendored_packages/pluggy.py", line 724, in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/_pytest/vendored_packages/pluggy.py", line 338, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/_pytest/vendored_packages/pluggy.py", line 333, in <lambda>
    _MultiCall(methods, kwargs, hook.spec_opts).execute()
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/_pytest/vendored_packages/pluggy.py", line 595, in execute
    return _wrapped_call(hook_impl.function(*args), self.execute)
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/_pytest/vendored_packages/pluggy.py", line 249, in _wrapped_call
    wrap_controller.send(call_outcome)
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/_pytest/helpconfig.py", line 28, in pytest_cmdline_parse
    config = outcome.get_result()
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/_pytest/vendored_packages/pluggy.py", line 278, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/_pytest/vendored_packages/pluggy.py", line 264, in __init__
    self.result = func()
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/_pytest/vendored_packages/pluggy.py", line 596, in execute
    res = hook_impl.function(*args)
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/_pytest/config.py", line 861, in pytest_cmdline_parse
    self.parse(args)
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/_pytest/config.py", line 966, in parse
    self._preparse(args, addopts=addopts)
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/_pytest/config.py", line 927, in _preparse
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/_pytest/vendored_packages/pluggy.py", line 501, in load_setuptools_entrypoints
    plugin = ep.load()
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/pkg_resources/__init__.py", line 2404, in load
    self.require(*args, **kwargs)
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/pkg_resources/__init__.py", line 2427, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages/pkg_resources/__init__.py", line 872, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.VersionConflict: (pytest 2.9.2 (/home/travis/virtualenv/python3.3.6/lib/python3.3/site-packages), Requirement.parse('pytest>=3.0.0'))
```
https://travis-ci.org/hugovk/requests/jobs/284048190

The other CI failures are related to cookies and also occur in latest master and fresh builds of proposed/3.0.0.