### PR TITLE
Python 3.7 is supported

### DIFF
--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -61,6 +61,7 @@ supported:
 * Python 3.4
 * Python 3.5
 * Python 3.6
+* Python 3.7
 * PyPy
 
 What are "hostname doesn't match" errors?

--- a/docs/dev/todo.rst
+++ b/docs/dev/todo.rst
@@ -56,6 +56,7 @@ Requests currently supports the following versions of Python:
 - Python 3.4
 - Python 3.5
 - Python 3.6
+- Python 3.7
 - PyPy
 
 Google AppEngine is not officially supported although support is available

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ),


### PR DESCRIPTION
The README says "Requests officially supports Python 2.6–2.7 & 3.3–3.7, and runs great on PyPy." so update the version in some other places too.