### PR TITLE
Warn about possible slowness on older versions of pyOpenSSL

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -178,3 +178,4 @@ Patches and Suggestions
 - Ryan Pineo (`@ryanpineo <https://github.com/ryanpineo>`_)
 - Ed Morley (`@edmorley <https://github.com/edmorley>`_)
 - Matt Liu <liumatt@gmail.com> (`@mlcrazy <https://github.com/mlcrazy>`_)
+- Taylor Hoff <primdevs@protonmail.com> (`@PrimordialHelios <https://github.com/PrimordialHelios>`_)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ dev
 
 **Improvements**
 
+- Warn user about possible slowdown when using cryptography version < 1.3.4
+
 **Bugfixes**
 
 - Parsing empty ``Link`` headers with ``parse_header_links()`` no longer return one bogus entry

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -71,6 +71,17 @@ def check_compatibility(urllib3_version, chardet_version):
     assert patch >= 2
 
 
+def _check_cryptography(cryptography_version):
+    # cryptography < 1.3.4
+    try:
+        cryptography_version = list(map(int, cryptography_version.split('.')))
+    except ValueError:
+        return
+
+    if cryptography_version < [1, 3, 4]:
+        warning = 'Old version of cryptography ({0}) may cause slowdown.'.format(cryptography_version)
+        warnings.warn(warning, RequestsDependencyWarning)
+
 # Check imported dependencies for compatibility.
 try:
     check_compatibility(urllib3.__version__, chardet.__version__)
@@ -83,6 +94,10 @@ except (AssertionError, ValueError):
 try:
     from urllib3.contrib import pyopenssl
     pyopenssl.inject_into_urllib3()
+
+    # Check cryptography version
+    from cryptography import __version__ as cryptography_version
+    _check_cryptography(cryptography_version)
 except ImportError:
     pass
 


### PR DESCRIPTION
Give a warning when `cryptography < 1.3.4` and `pyOpenSSL < 16.0.0` as discussed in #4309 