### PR TITLE
Respect the NETRC environment variable, if set.

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -207,7 +207,8 @@ Note: Custom headers are given less precedence than more specific sources of inf
 
 * Authorization headers set with `headers=` will be overridden if credentials
   are specified in ``.netrc``, which in turn will be overridden by the  ``auth=``
-  parameter.
+  parameter. Requests will search for the netrc file at `~/.netrc`, `~/_netrc`,
+  or at the path specified by the `NETRC` environment variable.
 * Authorization headers will be removed if you get redirected off-host.
 * Proxy-Authorization headers will be overridden by proxy credentials provided in the URL.
 * Content-Length headers will be overridden when we can determine the length of the content.

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -34,7 +34,7 @@ from .structures import CaseInsensitiveDict
 from .exceptions import (
     InvalidURL, InvalidHeader, FileModeWarning, UnrewindableBodyError)
 
-NETRC_FILES = ('.netrc', '_netrc')
+NETRC_FILES = os.environ.get('NETRC', ('~/.netrc', '~/_netrc'))
 
 DEFAULT_CA_BUNDLE_PATH = certs.where()
 
@@ -166,13 +166,14 @@ def get_netrc_auth(url, raise_errors=False):
         netrc_path = None
 
         for f in NETRC_FILES:
-            try:
-                loc = os.path.expanduser('~/{0}'.format(f))
-            except KeyError:
-                # os.path.expanduser can fail when $HOME is undefined and
-                # getpwuid fails. See http://bugs.python.org/issue20164 &
-                # https://github.com/requests/requests/issues/1846
-                return
+            if f.startswith('~'):
+                try:
+                    loc = os.path.expanduser('~/{0}'.format(f))
+                except KeyError:
+                    # os.path.expanduser can fail when $HOME is undefined and
+                    # getpwuid fails. See http://bugs.python.org/issue20164 &
+                    # https://github.com/requests/requests/issues/1846
+                    return
 
             if os.path.exists(loc):
                 netrc_path = loc

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -166,14 +166,13 @@ def get_netrc_auth(url, raise_errors=False):
         netrc_path = None
 
         for f in NETRC_FILES:
-            if f.startswith('~'):
-                try:
-                    loc = os.path.expanduser('~/{0}'.format(f))
-                except KeyError:
-                    # os.path.expanduser can fail when $HOME is undefined and
-                    # getpwuid fails. See http://bugs.python.org/issue20164 &
-                    # https://github.com/requests/requests/issues/1846
-                    return
+            try:
+                loc = os.path.expanduser('~/{0}'.format(f))
+            except KeyError:
+                # os.path.expanduser can fail when $HOME is undefined and
+                # getpwuid fails. See http://bugs.python.org/issue20164 &
+                # https://github.com/requests/requests/issues/1846
+                return
 
             if os.path.exists(loc):
                 netrc_path = loc

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -167,7 +167,7 @@ def get_netrc_auth(url, raise_errors=False):
 
         for f in NETRC_FILES:
             try:
-                loc = os.path.expanduser('~/{0}'.format(f))
+                loc = os.path.expanduser(f)
             except KeyError:
                 # os.path.expanduser can fail when $HOME is undefined and
                 # getpwuid fails. See http://bugs.python.org/issue20164 &


### PR DESCRIPTION
If the NETRC environment variable is set, use it to
load the user's netrc file. If not set, default to
searching the user's home directory for  a `.netrc`
or `_netrc` file.

Issue #4318