### PR TITLE
Python 3.7 not officially supported yet

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Requests is ready for today's web.
 - ``.netrc`` Support
 - Chunked Requests
 
-Requests officially supports Python 2.6–2.7 & 3.3–3.7, and runs great on PyPy.
+Requests officially supports Python 2.6–2.7 & 3.3–3.6, and runs great on PyPy.
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Requests is ready for today's web.
 - ``.netrc`` Support
 - Chunked Requests
 
-Requests officially supports Python 2.6–2.7 & 3.3–3.6, and runs great on PyPy.
+Requests officially supports Python 2.6–2.7 & 3.4–3.6, and runs great on PyPy.
 
 Installation
 ------------

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -39,7 +39,7 @@ from .models import REDIRECT_STATI
 
 # Preferred clock, based on which one is more accurate on a given system.
 if platform.system() == 'Windows':
-    try:  # Python 3.3+
+    try:  # Python 3.4+
         preferred_clock = time.perf_counter
     except AttributeError:  # Earlier than Python 3.
         preferred_clock = time.clock


### PR DESCRIPTION
We don't actually test on 3.7 and 3.7 isn't released for another eight months, so don't yet claim support.

Re: https://github.com/requests/requests/pull/4329#pullrequestreview-69421398 and closes https://github.com/requests/requests/pull/4329.

Also, Python 3.3 was also dropped in https://github.com/requests/requests/pull/4231 so remove mention of those.