### PR TITLE
Fix case-insensitive comparison in Session.get_adapter

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -696,7 +696,7 @@ class Session(SessionRedirectMixin):
         """
         for (prefix, adapter) in self.adapters.items():
 
-            if url.lower().startswith(prefix):
+            if url.lower().startswith(prefix.lower()):
                 return adapter
 
         # Nothing matches :-/

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1351,6 +1351,18 @@ class TestRequests:
         assert 'http://' in s2.adapters
         assert 'https://' in s2.adapters
 
+    def test_session_get_adapter_prefix_matching_is_case_insensitive(self, httpbin):
+        mixed_case_prefix = 'hTtPs://eXamPle.CoM/MixEd_CAse_PREfix'
+        url_matching_prefix = mixed_case_prefix + '/full_url'
+        url_matching_prefix_with_different_case = 'HtTpS://exaMPLe.cOm/MiXeD_caSE_preFIX/another_url'
+
+        s = requests.Session()
+        my_adapter = HTTPAdapter()
+        s.mount(mixed_case_prefix, my_adapter)
+
+        assert s.get_adapter(url_matching_prefix) is my_adapter
+        assert s.get_adapter(url_matching_prefix_with_different_case) is my_adapter
+
     def test_header_remove_is_case_insensitive(self, httpbin):
         # From issue #1321
         s = requests.Session()

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1369,16 +1369,24 @@ class TestRequests:
         assert s.get_adapter(url_matching_more_specific_prefix) is more_specific_prefix_adapter
         assert s.get_adapter(url_not_matching_prefix) not in (prefix_adapter, more_specific_prefix_adapter)
 
-    def test_session_get_adapter_prefix_matching_is_case_insensitive(self, httpbin):
+    def test_session_get_adapter_prefix_matching_mixed_case(self, httpbin):
         mixed_case_prefix = 'hTtPs://eXamPle.CoM/MixEd_CAse_PREfix'
         url_matching_prefix = mixed_case_prefix + '/full_url'
-        url_matching_prefix_with_different_case = 'HtTpS://exaMPLe.cOm/MiXeD_caSE_preFIX/another_url'
 
         s = requests.Session()
         my_adapter = HTTPAdapter()
         s.mount(mixed_case_prefix, my_adapter)
 
         assert s.get_adapter(url_matching_prefix) is my_adapter
+
+    def test_session_get_adapter_prefix_matching_is_case_insensitive(self, httpbin):
+        mixed_case_prefix = 'hTtPs://eXamPle.CoM/MixEd_CAse_PREfix'
+        url_matching_prefix_with_different_case = 'HtTpS://exaMPLe.cOm/MiXeD_caSE_preFIX/another_url'
+
+        s = requests.Session()
+        my_adapter = HTTPAdapter()
+        s.mount(mixed_case_prefix, my_adapter)
+
         assert s.get_adapter(url_matching_prefix_with_different_case) is my_adapter
 
     def test_header_remove_is_case_insensitive(self, httpbin):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1351,6 +1351,24 @@ class TestRequests:
         assert 'http://' in s2.adapters
         assert 'https://' in s2.adapters
 
+    def test_session_get_adapter_prefix_matching(self, httpbin):
+        prefix = 'https://example.com'
+        more_specific_prefix = prefix + '/some/path'
+
+        url_matching_only_prefix = prefix + '/another/path'
+        url_matching_more_specific_prefix = more_specific_prefix + '/longer/path'
+        url_not_matching_prefix = 'https://another.example.com/'
+
+        s = requests.Session()
+        prefix_adapter = HTTPAdapter()
+        more_specific_prefix_adapter = HTTPAdapter()
+        s.mount(prefix, prefix_adapter)
+        s.mount(more_specific_prefix, more_specific_prefix_adapter)
+
+        assert s.get_adapter(url_matching_only_prefix) is prefix_adapter
+        assert s.get_adapter(url_matching_more_specific_prefix) is more_specific_prefix_adapter
+        assert s.get_adapter(url_not_matching_prefix) not in (prefix_adapter, more_specific_prefix_adapter)
+
     def test_session_get_adapter_prefix_matching_is_case_insensitive(self, httpbin):
         mixed_case_prefix = 'hTtPs://eXamPle.CoM/MixEd_CAse_PREfix'
         url_matching_prefix = mixed_case_prefix + '/full_url'


### PR DESCRIPTION
While trying to get the adapter for an url, the url is lowered before comparing with the prefix, but the prefix is not, so if it contains non-lowercase characters (eg. `https://example.com/sOmE_WeiRD_pReFIX/`), it won't return the correct adapter.

The other solution is to lower the prefix while adding the adapter. I have opted for the first solution to isolate in one place the case-insensitivity feature.

Edit:
Another alternative could be to document that the prefix should be passed lowered to Session.mount() (this is what I am doing for now to work-around the issue).