### PR TITLE
Add something to the docs about hooks on Session()

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -452,11 +452,23 @@ If the callback function returns a value, it is assumed that it is to
 replace the data that was passed in. If the function doesn't return
 anything, nothing else is effected.
 
+::
+
+    def record_hook(r, *args, **kwargs):
+        r.hook_called = True
+        return r
+
 Let's print some request method arguments at runtime::
 
     >>> requests.get('http://httpbin.org', hooks={'response': print_url})
     http://httpbin.org
     <Response [200]>
+
+You can add multiple hooks to a single request.  Let's call two hooks at once::
+
+    >>> r = requests.get('http://httpbin.org', hooks={'response': [print_url, record_hook]})
+    >>> r.hook_called
+    True
 
 You can also add hooks to a ``Session`` instance.  Any hooks you add will then
 be called on every request made to the session.  For example::

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -458,6 +458,15 @@ Let's print some request method arguments at runtime::
     http://httpbin.org
     <Response [200]>
 
+You can also assign hooks to a ``Session`` instance.  The hook will then be
+called on every request made to the session.  For example::
+
+   >>> s = requests.Session()
+   >>> s.hooks = dict(response=print_url)
+   >>> s.get('http://httpbin.org')
+    http://httpbin.org
+    <Response [200]>
+
 .. _custom-auth:
 
 Custom Authentication

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -458,14 +458,17 @@ Let's print some request method arguments at runtime::
     http://httpbin.org
     <Response [200]>
 
-You can also assign hooks to a ``Session`` instance.  The hook will then be
-called on every request made to the session.  For example::
+You can also add hooks to a ``Session`` instance.  Any hooks you add will then
+be called on every request made to the session.  For example::
 
    >>> s = requests.Session()
    >>> s.hooks['response'].append(print_url)
    >>> s.get('http://httpbin.org')
     http://httpbin.org
     <Response [200]>
+
+A ``Session`` can have multiple hooks, which will be called in the order
+they are added.
 
 .. _custom-auth:
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -436,7 +436,7 @@ You can assign a hook function on a per-request basis by passing a
 ``{hook_name: callback_function}`` dictionary to the ``hooks`` request
 parameter::
 
-    hooks=dict(response=print_url)
+    hooks={'response': print_url}
 
 That ``callback_function`` will receive a chunk of data as its first
 argument.
@@ -454,7 +454,7 @@ anything, nothing else is effected.
 
 Let's print some request method arguments at runtime::
 
-    >>> requests.get('http://httpbin.org', hooks=dict(response=print_url))
+    >>> requests.get('http://httpbin.org', hooks={'response': print_url})
     http://httpbin.org
     <Response [200]>
 
@@ -462,7 +462,7 @@ You can also assign hooks to a ``Session`` instance.  The hook will then be
 called on every request made to the session.  For example::
 
    >>> s = requests.Session()
-   >>> s.hooks = dict(response=print_url)
+   >>> s.hooks['response'].append(print_url)
    >>> s.get('http://httpbin.org')
     http://httpbin.org
     <Response [200]>


### PR DESCRIPTION
I had to work this out by reading the source code for `Session` – better to put it front-and-centre in the docs.