### PR TITLE
[WIP] Fix e.response is None when ChunkedEncodingError occured

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -745,7 +745,7 @@ class Response(object):
                     for chunk in self.raw.stream(chunk_size, decode_content=True):
                         yield chunk
                 except ProtocolError as e:
-                    raise ChunkedEncodingError(e)
+                    raise ChunkedEncodingError(e, response=self)
                 except DecodeError as e:
                     raise ContentDecodingError(e)
                 except ReadTimeoutError as e:


### PR DESCRIPTION
Hi!
I found that it's impossible to read headers and response code when ChunkedEncodingError occured.

Here is demonstration code.
Server code:
```
#!/usr/bin/env python

import BaseHTTPServer
import SocketServer

class ChunkingHTTPServer(SocketServer.ThreadingMixIn,
                        BaseHTTPServer.HTTPServer):
    daemon_threads = True

class ChunkingRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
    ALWAYS_SEND_SOME = False
    ALLOW_GZIP = False
    protocol_version = 'HTTP/1.1'
    def do_GET(self):
        self.send_response(200)
        self.send_header('Transfer-Encoding', 'chunked')
        self.send_header('Content-type', 'text/plain')
        raise Exception()

if __name__ == '__main__':
    server = ChunkingHTTPServer(
        ('127.0.0.1', 8000), ChunkingRequestHandler)
    print 'Starting server, use <Ctrl-C> to stop'
    server.serve_forever()
```

Client code:
```
#!/usr/bin/env python

import requests

try:
    requests.get('http://127.0.0.1:8000')
except requests.exceptions.ChunkedEncodingError as e:
    print(e.response)
```

Before patch: None
After patch: <Response [200]>

I have problem with presenting this code for testing, just have no idea how to integrate it. Could someone help me with it, please.

Also I think that the same behavior is here:
 - https://github.com/requests/requests/blob/master/requests/models.py#L750
 - https://github.com/requests/requests/blob/master/requests/models.py#L752
But I don't know how to emulate these types of error

