### PR TITLE
support extraction of certificate bundle from a zip archive

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -179,3 +179,4 @@ Patches and Suggestions
 - Ed Morley (`@edmorley <https://github.com/edmorley>`_)
 - Matt Liu <liumatt@gmail.com> (`@mlcrazy <https://github.com/mlcrazy>`_)
 - Taylor Hoff <primdevs@protonmail.com> (`@PrimordialHelios <https://github.com/PrimordialHelios>`_)
+- Arthur Vigil (`@ahvigil <https://github.com/ahvigil>`_)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,9 @@ dev
 **Bugfixes**
 
 - Parsing empty ``Link`` headers with ``parse_header_links()`` no longer return one bogus entry
+- Fixed issue where loading the default certificate bundle from a zip archive
+  would raise an ``IOError``
+
 
 2.18.4 (2017-08-15)
 +++++++++++++++++++

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -28,9 +28,9 @@ from urllib3.exceptions import ResponseError
 
 from .models import Response
 from .compat import urlparse, basestring
-from .utils import (DEFAULT_CA_BUNDLE_PATH, get_encoding_from_headers,
-                    prepend_scheme_if_needed, get_auth_from_url, urldefragauth,
-                    select_proxy)
+from .utils import (DEFAULT_CA_BUNDLE_PATH, extract_zipped_paths,
+                    get_encoding_from_headers, prepend_scheme_if_needed,
+                    get_auth_from_url, urldefragauth, select_proxy)
 from .structures import CaseInsensitiveDict
 from .cookies import extract_cookies_to_jar
 from .exceptions import (ConnectionError, ConnectTimeout, ReadTimeout, SSLError,
@@ -219,7 +219,7 @@ class HTTPAdapter(BaseAdapter):
                 cert_loc = verify
 
             if not cert_loc:
-                cert_loc = DEFAULT_CA_BUNDLE_PATH
+                cert_loc = extract_zipped_paths(DEFAULT_CA_BUNDLE_PATH)
 
             if not cert_loc or not os.path.exists(cert_loc):
                 raise IOError("Could not find a suitable TLS CA certificate bundle, "


### PR DESCRIPTION
Resolves #4369 by checking whether the default CA certificate bundle is being imported from a zip archive. If it is, extract the certificate bundle to a temp folder so it can be handled by the standard OpenSSL libraries.