### PR TITLE
When Location decoding fails, fall back to original

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -113,7 +113,11 @@ class SessionRedirectMixin(object):
             # To solve this, we re-encode the location in latin1.
             if is_py3:
                 location = location.encode('latin1')
-            return to_native_string(location, 'utf8')
+            try:
+                return to_native_string(location, 'utf8')
+            except UnicodeDecodeError:
+                # The header was definitely not using UTF-8, retain original
+                return resp.headers['location']
         return None
 
     def resolve_redirects(self, resp, req, stream=False, timeout=None,

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -205,7 +205,7 @@ def test_use_proxy_from_environment(httpbin, var, scheme):
         assert len(fake_proxy.handler_results[0]) > 0
 
 
-def test_redirect_rfc1808_to_non_ascii_location():
+def test_redirect_rfc1808_to_utf8_location():
     path = u'š'
     expected_path = b'%C5%A1'
     redirect_request = []  # stores the second request to the server
@@ -217,6 +217,37 @@ def test_redirect_rfc1808_to_non_ascii_location():
             b'HTTP/1.1 301 Moved Permanently\r\n'
             b'Content-Length: 0\r\n'
             b'Location: ' + location.encode('utf8') + b'\r\n'
+            b'\r\n'
+        )
+        redirect_request.append(consume_socket_content(sock, timeout=0.5))
+        sock.send(b'HTTP/1.1 200 OK\r\n\r\n')
+
+    close_server = threading.Event()
+    server = Server(redirect_resp_handler, wait_to_close_event=close_server)
+
+    with server as (host, port):
+        url = u'http://{0}:{1}'.format(host, port)
+        r = requests.get(url=url, allow_redirects=True)
+        assert r.status_code == 200
+        assert len(r.history) == 1
+        assert r.history[0].status_code == 301
+        assert redirect_request[0].startswith(b'GET /' + expected_path + b' HTTP/1.1')
+        assert r.url == u'{0}/{1}'.format(url, expected_path.decode('ascii'))
+
+        close_server.set()
+
+def test_redirect_rfc1808_to_latin1_location():
+    path = u'å'
+    expected_path = b'%C3%A5'
+    redirect_request = []  # stores the second request to the server
+
+    def redirect_resp_handler(sock):
+        consume_socket_content(sock, timeout=0.5)
+        location = u'//{0}:{1}/{2}'.format(host, port, path)
+        sock.send(
+            b'HTTP/1.1 301 Moved Permanently\r\n'
+            b'Content-Length: 0\r\n'
+            b'Location: ' + location.encode('latin-1') + b'\r\n'
             b'\r\n'
         )
         redirect_request.append(consume_socket_content(sock, timeout=0.5))


### PR DESCRIPTION
Issue #3888 correctly identified Location headers as *usually* containing UTF-8
codepoints (when not correctly URL encoded), but this is not always the case.
For example the URL
http://www.finanzen.net/suchergebnis.asp?strSuchString=DE0005933931 redirects
to `b'/etf/ishares_core_dax\xae_ucits_etf_de'`, containing the Latin-1 byte for
the ® character.

If UTF-8 decoding fails, it is better to fall back to the original.

This issue was found via https://stackoverflow.com/questions/47113376/python-3-x-requests-redirect-with-unicode-character