### PR TITLE
for RFC-7616 add SHA-256 and SHA-512

### DIFF
--- a/requests/auth.py
+++ b/requests/auth.py
@@ -153,6 +153,18 @@ class HTTPDigestAuth(AuthBase):
                     x = x.encode('utf-8')
                 return hashlib.sha1(x).hexdigest()
             hash_utf8 = sha_utf8
+        elif _algorithm == 'SHA-256':
+            def sha256_utf8(x):
+                if isinstance(x, str):
+                    x = x.encode('utf-8')
+                return hashlib.sha256(x).hexdigest()
+            hash_utf8 = sha256_utf8
+        elif _algorithm == 'SHA-512':
+            def sha512_utf8(x):
+                if isinstance(x, str):
+                    x = x.encode('utf-8')
+                return hashlib.sha512(x).hexdigest()
+            hash_utf8 = sha512_utf8
 
         KD = lambda s, d: hash_utf8("%s:%s" % (s, d))
 


### PR DESCRIPTION
While working with some FIPS libraries that disabled MD5, we ran into a problem with our Requests based tools not being able to talk to our server. 

<img width="1440" alt="screen shot 2017-11-08 at 4 19 47 pm" src="https://user-images.githubusercontent.com/438131/32584052-c4a29c36-c4b3-11e7-8ca1-7601c60c60f2.png">

I haven't fully read the RFC-7616 SHA-256 and SHA-512 standards but this patch works.

Thanks for Requests!
