### PR TITLE
utils: winreg module may not exist like on windows universal platform.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,7 @@ dev
 - Parsing empty ``Link`` headers with ``parse_header_links()`` no longer return one bogus entry
 - Fixed issue where loading the default certificate bundle from a zip archive
   would raise an ``IOError``
+- Fixed issue with unexpected ``ImportError`` on windows system which do not support ``winreg`` module
 
 
 2.18.4 (2017-08-15)

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -45,10 +45,14 @@ if sys.platform == 'win32':
     # provide a proxy_bypass version on Windows without DNS lookups
 
     def proxy_bypass_registry(host):
-        if is_py3:
-            import winreg
-        else:
-            import _winreg as winreg
+        try:
+            if is_py3:
+                import winreg
+            else:
+                import _winreg as winreg
+        except ImportError:
+            return False
+
         try:
             internetSettings = winreg.OpenKey(winreg.HKEY_CURRENT_USER,
                 r'Software\Microsoft\Windows\CurrentVersion\Internet Settings')


### PR DESCRIPTION
UWP has no API to get access to windows registry, so python has no winreg module on UWP.
This fixes unexpected error on UWP.