### PR TITLE
[docs; tiny] Clarify that Response.ok will *only* return True/False

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -686,11 +686,11 @@ class Response(object):
 
     @property
     def ok(self):
-        """Returns True if :attr:`status_code` is less than 400.
+        """Returns True if :attr:`status_code` is less than 400, False if not.
 
         This attribute checks if the status code of the response is between
         400 and 600 to see if there was a client error or a server error. If
-        the status code, is between 200 and 400, this will return True. This
+        the status code is between 200 and 400, this will return True. This
         is **not** a check to see if the response code is ``200 OK``.
         """
         try:


### PR DESCRIPTION
This is a tiny documentation fix, just to be super-duper explicit about the return value of `response.ok`.

(I wanted to check I could use its value in a function that’s meant to return a boolean, but the docs weren’t clear about what a non-Truthy return value would be.)