### PR TITLE
Empty file stream should be set to Content-Length:0

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -486,7 +486,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             if files:
                 raise NotImplementedError('Streamed bodies and files are mutually exclusive.')
 
-            if length:
+            if length is not None:
                 self.headers['Content-Length'] = builtin_str(length)
             else:
                 self.headers['Transfer-Encoding'] = 'chunked'

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -157,10 +157,10 @@ def super_len(o):
                     # partially read file-like objects
                     o.seek(current_position or 0)
                 except (OSError, IOError):
-                    total_length = 0
+                    total_length = None
 
     if total_length is None:
-        total_length = 0
+        return None
 
     return max(0, total_length - current_position)
 


### PR DESCRIPTION
I have trouble in uploading empty files  to AWS S3 using requests, the point is that AWS S3 doesn't support Transfer-Encoding: chunked to upload files.

Dealing with the file pointer(fp) which points to an empty file, requests  set it to Transfer-Encoding: chunked. In fact, the length of empty file can be calculated by the function super_len() without raising exception, the length is zero, but requests treats it same with None(caused by exceptions)!
```python
try:
    length = super_len(data)
except (TypeError, AttributeError, UnsupportedOperation):
    length = None
```
I touched an empty file named empty.txt, and the result is 'Transfer-Encoding': 'chunked' instead of 'Content-Length': '0'. In this situation, i think the result should be 'Content-Length': '0', since the length of the file can be calculated!
```python
>>> import requests
>>> fp = open('empty.txt', 'rb')
>>> r = requests.put('http://httpbin.org/put', data=fp)
>>> r.request.headers
{'Transfer-Encoding': 'chunked', 'Connection': 'keep-alive', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'User-Agent': 'python-requests/2.18.4'}
>>> fp.close()
'''
