### PR TITLE
Use single default ssl_context in HTTPAdapter connection pool manager

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -389,7 +389,7 @@ class Session(SessionRedirectMixin):
 
         # Default connection adapters.
         self.adapters = OrderedDict()
-        self.mount('https://', HTTPAdapter())
+        self.mount('https://', HTTPAdapter(with_ssl=True))
         self.mount('http://', HTTPAdapter())
 
     def __enter__(self):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2438,3 +2438,13 @@ class TestPreparingURLs(object):
         r = requests.Request('GET', url=input, params=params)
         p = r.prepare()
         assert p.url == expected
+
+def test_single_ssl_context():
+    conn = HTTPAdapter(with_ssl=True).get_connection('https://example.com')
+    c1 = conn._new_conn().ssl_context
+    assert c1 is not None
+    assert c1 is conn._new_conn().ssl_context
+
+def test_http_no_default_ssl_context():
+    adapter = HTTPAdapter()
+    assert adapter._ssl_context is None


### PR DESCRIPTION
Creates default SSLContext object for each HTTPAdapter that is expected to be used for https requests.

There are just a few small changes for:
- Adding a default SSLContext object only to the https HTTPAdapter in each session (not the http one)
- Creating the default object using the same urllib3 function that would be used to create a default SSLContext for each connection
- Adding ssl_context to poolmanager's connection_pool_kw to get passed down to all connections
- Pickling HTTPAdapter with the new attribute
- Breaking up the HTTPAdapter's send method a little (this is not related, I was just there anyway.  I'm happy to undo that if it's not wanted.  There are separate functions for getting the timeout and sending chunked now.)

Any feedback is welcome!  This is for https://github.com/requests/requests/issues/4322

