### PR TITLE
Add SHA-256 and SHA-512 digest auth algorithms

### DIFF
--- a/requests/auth.py
+++ b/requests/auth.py
@@ -153,6 +153,18 @@ class HTTPDigestAuth(AuthBase):
                     x = x.encode('utf-8')
                 return hashlib.sha1(x).hexdigest()
             hash_utf8 = sha_utf8
+        elif _algorithm == 'SHA-256':
+            def sha256_utf8(x):
+                if isinstance(x, str):
+                    x = x.encode('utf-8')
+                return hashlib.sha256(x).hexdigest()
+            hash_utf8 = sha256_utf8
+        elif _algorithm == 'SHA-512':
+            def sha512_utf8(x):
+                if isinstance(x, str):
+                    x = x.encode('utf-8')
+                return hashlib.sha512(x).hexdigest()
+            hash_utf8 = sha512_utf8
 
         KD = lambda s, d: hash_utf8("%s:%s" % (s, d))
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -54,6 +54,8 @@ except AttributeError:
 
 class TestRequests:
 
+    digest_auth_algo = ('MD5', 'SHA-256', 'SHA-512')
+
     def test_entry_points(self):
 
         requests.session
@@ -574,70 +576,79 @@ class TestRequests:
 
     def test_DIGEST_HTTP_200_OK_GET(self, httpbin):
 
-        auth = HTTPDigestAuth('user', 'pass')
-        url = httpbin('digest-auth', 'auth', 'user', 'pass')
+        for authtype in self.digest_auth_algo:
+            auth = HTTPDigestAuth('user', 'pass')
+            url = httpbin('digest-auth', 'auth', 'user', 'pass', authtype, 'never')
 
-        r = requests.get(url, auth=auth)
-        assert r.status_code == 200
+            r = requests.get(url, auth=auth)
+            assert r.status_code == 200
 
-        r = requests.get(url)
-        assert r.status_code == 401
+            r = requests.get(url)
+            assert r.status_code == 401
+            print(r.headers['WWW-Authenticate'])
 
-        s = requests.session()
-        s.auth = HTTPDigestAuth('user', 'pass')
-        r = s.get(url)
-        assert r.status_code == 200
+            s = requests.session()
+            s.auth = HTTPDigestAuth('user', 'pass')
+            r = s.get(url)
+            assert r.status_code == 200
 
     def test_DIGEST_AUTH_RETURNS_COOKIE(self, httpbin):
-        url = httpbin('digest-auth', 'auth', 'user', 'pass')
-        auth = HTTPDigestAuth('user', 'pass')
-        r = requests.get(url)
-        assert r.cookies['fake'] == 'fake_value'
 
-        r = requests.get(url, auth=auth)
-        assert r.status_code == 200
+        for authtype in self.digest_auth_algo:
+            url = httpbin('digest-auth', 'auth', 'user', 'pass', authtype)
+            auth = HTTPDigestAuth('user', 'pass')
+            r = requests.get(url)
+            assert r.cookies['fake'] == 'fake_value'
+
+            r = requests.get(url, auth=auth)
+            assert r.status_code == 200
 
     def test_DIGEST_AUTH_SETS_SESSION_COOKIES(self, httpbin):
-        url = httpbin('digest-auth', 'auth', 'user', 'pass')
-        auth = HTTPDigestAuth('user', 'pass')
-        s = requests.Session()
-        s.get(url, auth=auth)
-        assert s.cookies['fake'] == 'fake_value'
+
+        for authtype in self.digest_auth_algo:
+            url = httpbin('digest-auth', 'auth', 'user', 'pass', authtype)
+            auth = HTTPDigestAuth('user', 'pass')
+            s = requests.Session()
+            s.get(url, auth=auth)
+            assert s.cookies['fake'] == 'fake_value'
 
     def test_DIGEST_STREAM(self, httpbin):
 
-        auth = HTTPDigestAuth('user', 'pass')
-        url = httpbin('digest-auth', 'auth', 'user', 'pass')
+        for authtype in self.digest_auth_algo:
+            auth = HTTPDigestAuth('user', 'pass')
+            url = httpbin('digest-auth', 'auth', 'user', 'pass', authtype)
 
-        r = requests.get(url, auth=auth, stream=True)
-        assert r.raw.read() != b''
+            r = requests.get(url, auth=auth, stream=True)
+            assert r.raw.read() != b''
 
-        r = requests.get(url, auth=auth, stream=False)
-        assert r.raw.read() == b''
+            r = requests.get(url, auth=auth, stream=False)
+            assert r.raw.read() == b''
 
     def test_DIGESTAUTH_WRONG_HTTP_401_GET(self, httpbin):
 
-        auth = HTTPDigestAuth('user', 'wrongpass')
-        url = httpbin('digest-auth', 'auth', 'user', 'pass')
+        for authtype in self.digest_auth_algo:
+            auth = HTTPDigestAuth('user', 'wrongpass')
+            url = httpbin('digest-auth', 'auth', 'user', 'pass', authtype)
 
-        r = requests.get(url, auth=auth)
-        assert r.status_code == 401
+            r = requests.get(url, auth=auth)
+            assert r.status_code == 401
 
-        r = requests.get(url)
-        assert r.status_code == 401
+            r = requests.get(url)
+            assert r.status_code == 401
 
-        s = requests.session()
-        s.auth = auth
-        r = s.get(url)
-        assert r.status_code == 401
+            s = requests.session()
+            s.auth = auth
+            r = s.get(url)
+            assert r.status_code == 401
 
     def test_DIGESTAUTH_QUOTES_QOP_VALUE(self, httpbin):
 
-        auth = HTTPDigestAuth('user', 'pass')
-        url = httpbin('digest-auth', 'auth', 'user', 'pass')
+        for authtype in self.digest_auth_algo:
+            auth = HTTPDigestAuth('user', 'pass')
+            url = httpbin('digest-auth', 'auth', 'user', 'pass', authtype)
 
-        r = requests.get(url, auth=auth)
-        assert '"auth"' in r.request.headers['Authorization']
+            r = requests.get(url, auth=auth)
+            assert '"auth"' in r.request.headers['Authorization']
 
     def test_POSTBIN_GET_POST_FILES(self, httpbin):
 


### PR DESCRIPTION
Added SHA-256 and SHA-512 auth algorithms to requests/auth.py   Added test code to test_requests.py

Requires SHA-256 and SHA-512 in the httpbin test framework.