### PR TITLE
Fix: Removed incorrect plural of 'status'

### DIFF
--- a/requests/status_codes.py
+++ b/requests/status_codes.py
@@ -34,7 +34,7 @@ _codes = {
     204: ('no_content',),
     205: ('reset_content', 'reset'),
     206: ('partial_content', 'partial'),
-    207: ('multi_status', 'multiple_status', 'multi_stati', 'multiple_stati'),
+    207: ('multi_status', 'multiple_status'),
     208: ('already_reported',),
     226: ('im_used',),
 


### PR DESCRIPTION
The plural of `status` is `statuses` or `statūs`. Please disregard if it's here for a particular reason. 

https://en.wiktionary.org/wiki/status#English 
https://en.wiktionary.org/wiki/status#Etymology_2_2