### PR TITLE
Fix broken link to Certifi

### DIFF
--- a/docs/community/recommended.rst
+++ b/docs/community/recommended.rst
@@ -15,7 +15,7 @@ Certifi CA Bundle
 validating the trustworthiness of SSL certificates while verifying the
 identity of TLS hosts. It has been extracted from the Requests project.
 
-.. _Certifi: http://certifi.io/en/latest/
+.. _Certifi: https://github.com/certifi/python-certifi
 
 CacheControl
 ------------


### PR DESCRIPTION
certifi.io doesn't available at least since 07.11.2017
(https://github.com/certifi/certifi.io/issues/16)