### PR TITLE
append previous url fragment on redirect

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -123,6 +123,7 @@ class SessionRedirectMixin(object):
         hist = []  # keep track of history
 
         url = self.get_redirect_target(resp)
+        previous_fragment = urlparse(req.url).fragment
         while url:
             prepared_request = req.copy()
 
@@ -147,8 +148,12 @@ class SessionRedirectMixin(object):
                 parsed_rurl = urlparse(resp.url)
                 url = '%s:%s' % (to_native_string(parsed_rurl.scheme), url)
 
-            # The scheme should be lower case...
+            # Normalize url case and attach previous fragment if needed (RFC 7231 7.1.2)
             parsed = urlparse(url)
+            if parsed.fragment == '' and previous_fragment:
+                parsed = parsed._replace(fragment=previous_fragment)
+            elif parsed.fragment:
+                previous_fragment = parsed.fragment
             url = parsed.geturl()
 
             # Facilitate relative 'location' headers, as allowed by RFC 7231.

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -294,6 +294,14 @@ class TestRequests:
         for header in purged_headers:
             assert header not in next_resp.request.headers
 
+    def test_fragment_maintained_on_redirect(self, httpbin):
+        fragment = "#view=edit&token=hunter2"
+        r = requests.get(httpbin('redirect-to?url=get')+fragment)
+
+        assert len(r.history) > 0
+        assert r.history[0].request.url == httpbin('redirect-to?url=get')+fragment
+        assert r.url == httpbin('get')+fragment
+
     def test_HTTP_200_OK_GET_WITH_PARAMS(self, httpbin):
         heads = {'User-agent': 'Mozilla/5.0'}
 


### PR DESCRIPTION
This PR should address #4443 by appending the original request's fragment to subsequent redirects, unless a new fragment is provided in the Location header. This behaviour should bring us into compliance with [RFC 7230 § 7.1.2](https://tools.ietf.org/html/rfc7231#section-7.1.2). I also wrote a test to confirm we don't send fragment information to new servers, our underlying implementation strips that.

One outstanding question I do have though is about chained redirects. 

-----

Let's say we make a request (`http://url#alice`) and get a 302 response (`http://new_url#bob`). We would leave `#bob` as the fragment for the second request. When we request `http://new_url#bob`, we get back another 301 to `http://final_url/`. Do we append `alice` or `bob` at this point? 

I went with the assumption that the "original" request is the first one in the chain. I could see an argument that all requests are stateless though, and that the `new_url#bob` is the only originating request in scope for the second redirect.