### PR TITLE
Fixing max_retries to accept Retry instance

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -113,7 +113,7 @@ class HTTPAdapter(BaseAdapter):
                  pool_block=DEFAULT_POOLBLOCK):
         if max_retries == DEFAULT_RETRIES:
             self.max_retries = Retry(0, read=False)
-        else:
+        elif isinstance(max_retries, int):
             self.max_retries = Retry.from_int(max_retries)
         self.config = {}
         self.proxy_manager = {}

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -115,6 +115,8 @@ class HTTPAdapter(BaseAdapter):
             self.max_retries = Retry(0, read=False)
         elif isinstance(max_retries, int):
             self.max_retries = Retry.from_int(max_retries)
+        else:
+            self.max_retries = max_retries
         self.config = {}
         self.proxy_manager = {}
 


### PR DESCRIPTION
adapters. HTTPAdapter max_retries parameter specifies that you can pass an instance of the Retry class directly to it.  

>     :param max_retries: The maximum number of retries each connection
>         should attempt. Note, this applies only to failed DNS lookups, socket
>         connections and connection timeouts, never to requests where data has
>         made it to the server. By default, Requests does not retry failed
>         connections. If you need granular control over the conditions under
>         which we retry a request, import urllib3's ``Retry`` class and pass
>         that instead.

However, lines 114-116 of the code will instead put instance of the Retry class into a parameter of the Retry.from_int() function.  The result is, once invoked during a retry, this error chain occurs:

>   File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 469, in get
>     return self.request('GET', url, **kwargs)
>   File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 457, in request
>     resp = self.send(prep, **send_kwargs)
>   File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 569, in send
>     r = adapter.send(request, **kwargs)
>   File "/usr/lib/python2.7/dist-packages/requests/adapters.py", line 362, in send
>     timeout=timeout
>   File "/usr/lib/python2.7/dist-packages/urllib3/connectionpool.py", line 559, in urlopen
>     _pool=self, _stacktrace=stacktrace)
>   File "/usr/lib/python2.7/dist-packages/urllib3/util/retry.py", line 227, in increment
>     total -= 1
> TypeError: unsupported operand type(s) for -=: 'Retry' and 'int'

This patch checks to see if max_retries is an int before passing it to Retry.from_int().  That way, if max_retries is already an instance of Retry, it will be left intact and function as documented.

Some cursory searches for the above TypeError indicate that this has been an undiagnosed problem across the net for quite a while.

Cheers!