### PR TITLE
Remove unsupported Python 3.3 from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,py36
+envlist = py26,py27,py34,py35,py36
 
 [testenv]
 


### PR DESCRIPTION
Python 3.3 is not a supported version so don't test it.