### PR TITLE
Start testing 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  # - "3.7-dev"
+  - "3.7-dev"
   # - "pypy"  -- appears to hang
   # - "pypy3"
 # command to install dependencies


### PR DESCRIPTION
Given that 3.7 is [now in beta](https://twitter.com/gvanrossum/status/958930025603977216) and scheduled for release in ~4 months, we should probably start testing it again.

EDIT: As far as I can tell appveyor hasn't had support for 3.7 added yet, likely due to it being an alpha release. We'll want to add that later when it becomes available.