### PR TITLE
Pass kwargs from adapter send call to add_headers, per documentation

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -411,7 +411,7 @@ class HTTPAdapter(BaseAdapter):
 
         self.cert_verify(conn, request.url, verify, cert)
         url = self.request_url(request, proxies)
-        self.add_headers(request)
+        self.add_headers(request, stream=stream, timeout=timeout, verify=verify, cert=cert, proxies=proxies)
 
         chunked = not (request.body is None or 'Content-Length' in request.headers)
 


### PR DESCRIPTION
The docstring for `HTTPAdapter.add_headers` implies that keyword args from the `send` call will be passed into `add_headers` – this change passes them in.  This would be helpful, particularly for kwargs like `timeout`, which may influence the headers that need to be added by an `HTTPAdapter` subclass.