### PR TITLE
Trim trialing white space throughout the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,3 @@ jobs:
     - stage: coverage
       python: 3.6
       script: codecov
-
-

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -67,4 +67,3 @@
   <li><a href="http://it.python-requests.org/">Italian</a></li>
   <li><a href="http://es.python-requests.org/">Spanish</a></li>
 </ul>
-

--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -59,4 +59,3 @@
   <li><a href="http://it.python-requests.org/">Italian</a></li>
   <li><a href="http://es.python-requests.org/">Spanish</a></li>
 </ul>
-

--- a/docs/community/recommended.rst
+++ b/docs/community/recommended.rst
@@ -62,6 +62,3 @@ Betamax
 A VCR imitation designed only for Python-Requests.
 
 .. _betamax: https://github.com/sigmavirus24/betamax
-
-
-

--- a/docs/community/updates.rst
+++ b/docs/community/updates.rst
@@ -29,4 +29,3 @@ Release and Version History
 ===========================
 
 .. include:: ../../HISTORY.rst
-

--- a/docs/dev/todo.rst
+++ b/docs/dev/todo.rst
@@ -62,4 +62,3 @@ Google AppEngine is not officially supported although support is available
 with the `Requests-Toolbelt`_.
 
 .. _Requests-Toolbelt: https://toolbelt.readthedocs.io/
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,8 +30,8 @@ consumption.
 
 .. note:: The use of **Python 3** is *highly* preferred over Python 2. Consider upgrading your applications and infrastructure if you find yourself *still* using Python 2 in production today. If you are using Python 3, congratulations — you are indeed a person of excellent taste.
   —*Kenneth Reitz*
-  
-  
+
+
 -------------------
 
 **Behold, the power of Requests**::

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -196,18 +196,18 @@ As a result an ``SSL: CERTIFICATE_VERIFY_FAILED`` is thrown.
 You can get around this behaviour by explicity merging the environment settings into your session::
 
     from requests import Request, Session
-    
+
     s = Session()
     req = Request('GET', url)
-    
+
     prepped = s.prepare_request(req)
-    
+
     # Merge environment settings into session
     settings = s.merge_environment_settings(prepped.url, None, None, None, None)
     resp = s.send(prepped, **settings)
-    
+
     print(resp.status_code)
-    
+
 .. _verification:
 
 SSL Cert Verification


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all in one go, it helps keep future diffs cleaner by avoiding spurious white space changes on unrelated lines.