### PR TITLE
Remove remaining references to removed, vendored packages

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -181,7 +181,7 @@ API Changes
 
       logging.basicConfig() # you need to initialize logging, otherwise you will not see anything from requests
       logging.getLogger().setLevel(logging.DEBUG)
-      requests_log = logging.getLogger("requests.packages.urllib3")
+      requests_log = logging.getLogger("urllib3")
       requests_log.setLevel(logging.DEBUG)
       requests_log.propagate = True
 

--- a/docs/community/release-process.rst
+++ b/docs/community/release-process.rst
@@ -19,19 +19,18 @@ Breaking changes are changes that break backwards compatibility with prior
 versions. If the project were to change the ``text`` attribute on a
 ``Response`` object to a method, that would only happen in a Major release.
 
-Major releases may also include miscellaneous bug fixes and upgrades to
-vendored packages. The core developers of Requests are committed to providing
-a good user experience. This means we're also committed to preserving
-backwards compatibility as much as possible. Major releases will be infrequent
-and will need strong justifications before they are considered.
+Major releases may also include miscellaneous bug fixes. The core developers of
+Requests are committed to providing a good user experience. This means we're
+also committed to preserving backwards compatibility as much as possible. Major
+releases will be infrequent and will need strong justifications before they are
+considered.
 
 Minor Releases
 --------------
 
-A minor release will not include breaking changes but may include
-miscellaneous bug fixes and upgrades to vendored packages. If the previous
-version of Requests released was ``v10.2.7`` a minor release would be
-versioned as ``v10.3.0``.
+A minor release will not include breaking changes but may include miscellaneous
+bug fixes. If the previous version of Requests released was ``v10.2.7`` a minor
+release would be versioned as ``v10.3.0``.
 
 Minor releases will be backwards compatible with releases that have the same
 major version number. In other words, all versions that would start with

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -950,9 +950,9 @@ passed-through to `urllib3`. We'll make a Transport Adapter that instructs the
 library to use SSLv3::
 
     import ssl
+    from urllib3.poolmanager import PoolManager
 
     from requests.adapters import HTTPAdapter
-    from requests.packages.urllib3.poolmanager import PoolManager
 
 
     class Ssl3HttpAdapter(HTTPAdapter):

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -171,7 +171,7 @@ server, you can access ``r.raw``. If you want to do this, make sure you set
     >>> r = requests.get('https://api.github.com/events', stream=True)
 
     >>> r.raw
-    <requests.packages.urllib3.response.HTTPResponse object at 0x101194810>
+    <urllib3.response.HTTPResponse object at 0x101194810>
 
     >>> r.raw.read(10)
     '\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03'

--- a/requests/help.py
+++ b/requests/help.py
@@ -13,7 +13,7 @@ import chardet
 from . import __version__ as requests_version
 
 try:
-    from .packages.urllib3.contrib import pyopenssl
+    from urllib3.contrib import pyopenssl
 except ImportError:
     pyopenssl = None
     OpenSSL = None


### PR DESCRIPTION
As the vendored packages were removing in version 2.16, all remaining
doc references should be replaced with newer practices.