### PR TITLE
Add PURGE verb

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -112,7 +112,7 @@ from .__version__ import __copyright__, __cake__
 from . import utils
 from . import packages
 from .models import Request, Response, PreparedRequest
-from .api import request, get, head, post, patch, put, delete, options
+from .api import request, get, head, post, patch, put, delete, options, purge
 from .sessions import session, Session
 from .status_codes import codes
 from .exceptions import (

--- a/requests/api.py
+++ b/requests/api.py
@@ -150,3 +150,16 @@ def delete(url, **kwargs):
     """
 
     return request('delete', url, **kwargs)
+
+
+def purge(url, **kwargs):
+    r"""Sends a PURGE request.
+
+    :param url: URL for the new :class:`Request` object.
+    :param \*\*kwargs: Optional arguments that ``request`` takes.
+    :return: :class:`Response <Response>` object
+    :rtype: requests.Response
+    """
+
+    kwargs.setdefault('allow_redirects', True)
+    return request('purge', url, **kwargs)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -93,12 +93,12 @@ class TestRequests:
         req = requests.Request(method, httpbin(method.lower())).prepare()
         assert 'Content-Length' not in req.headers
 
-    @pytest.mark.parametrize('method', ('POST', 'PUT', 'PATCH', 'OPTIONS'))
+    @pytest.mark.parametrize('method', ('POST', 'PUT', 'PATCH', 'OPTIONS', 'PURGE'))
     def test_no_body_content_length(self, httpbin, method):
         req = requests.Request(method, httpbin(method.lower())).prepare()
         assert req.headers['Content-Length'] == '0'
 
-    @pytest.mark.parametrize('method', ('POST', 'PUT', 'PATCH', 'OPTIONS'))
+    @pytest.mark.parametrize('method', ('POST', 'PUT', 'PATCH', 'OPTIONS', 'PURGE'))
     def test_empty_content_length(self, httpbin, method):
         req = requests.Request(method, httpbin(method.lower()), data='').prepare()
         assert req.headers['Content-Length'] == '0'


### PR DESCRIPTION
Many packages have established PURGE as a defacto HTTP verb for flushing caches.
This implements the new verb.