### PR TITLE
add comment about json parameter changing content-type

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -283,6 +283,8 @@ the ``json`` parameter (added in version 2.4.2) and it will be encoded automatic
 
 Note, the ``json`` parameter is ignored if either ``data`` or ``files`` is passed.
 
+Using the ``json`` parameter in the request will change the ``Content-Type`` in the header to ``application/json``.
+
 POST a Multipart-Encoded File
 -----------------------------
 


### PR DESCRIPTION
This comment clarifies that the json parameter in a post request automatically changes the content-type in the headers to application/json. Closes #4538.