### PR TITLE
Session timeout / Added the ability to set a default session timeout

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -397,6 +397,9 @@ class Session(SessionRedirectMixin):
         self.mount('https://', HTTPAdapter())
         self.mount('http://', HTTPAdapter())
 
+        # Set default timeout
+        self.timeout = None
+
     def __enter__(self):
         return self
 
@@ -506,7 +509,7 @@ class Session(SessionRedirectMixin):
 
         # Send the request.
         send_kwargs = {
-            'timeout': timeout,
+            'timeout': timeout or self.timeout,
             'allow_redirects': allow_redirects,
         }
         send_kwargs.update(settings)
@@ -602,6 +605,7 @@ class Session(SessionRedirectMixin):
         kwargs.setdefault('verify', self.verify)
         kwargs.setdefault('cert', self.cert)
         kwargs.setdefault('proxies', self.proxies)
+        kwargs.setdefault('timeout', self.timeout)
 
         # It's possible that users might accidentally send a Request object.
         # Guard against that specific failure case.

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -339,7 +339,7 @@ class Session(SessionRedirectMixin):
     __attrs__ = [
         'headers', 'cookies', 'auth', 'proxies', 'hooks', 'params', 'verify',
         'cert', 'prefetch', 'adapters', 'stream', 'trust_env',
-        'max_redirects',
+        'max_redirects', 'timeout'
     ]
 
     def __init__(self):


### PR DESCRIPTION
This is a very minimal PR that aims to allow developers to assign a default timeout to requests made using `Requests`, while not breaking any existing usage of the library. I open it following bumping into the problem of a request hanging indefinitely several times and reading through the open issues - specifically @kennethreitz 's comment here regarding assigning a default timeout to the lib: https://github.com/requests/requests/issues/3070#issuecomment-318926146

In essence, it allows a user to set a default timeout for a `Session` object so that any request made using that session will default to the session timeout unless specifically assigned a timeout of its own. I attempted to circumvent the entire issue of breaking existing code or deciding on the right default timeout for the library itself, instead just giving the user a tool to set it per session where necessary, instead of once per request.

The only open issue I am aware of is that if a request is specifically assigned to never timeout (`timeout=None`) and the session it is sent from has a default timeout set, then the session timeout will take. However, I believe that in such a case it makes sense to send the request from a new session.

Happy to receive any feedback. Thanks in advance!