### PR TITLE
respect reply-afer in automatic redirects

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -226,6 +226,11 @@ class SessionRedirectMixin(object):
                 extract_cookies_to_jar(self.cookies, prepared_request, resp.raw)
 
                 # extract redirect url, if any, for the next loop
+                if resp.is_redirect and len(hist) < self.max_redirects:
+                    retry_after = resp.headers.get('retry-after', None)
+                    if retry_after is not None:
+                        time.sleep(int(retry_after))
+
                 url = self.get_redirect_target(resp)
                 yield resp
 


### PR DESCRIPTION
small patch that respects replay-after only in automatic redirects .. similar to chrome, firefox and others.

 reply-after is not handled for other status codes such as 503, and 429 as the handling may application specific.  

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After