### PR TITLE
Migrate to new PyPI website

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,5 +1,5 @@
 [[source]]
-url = "https://pypi.python.org/simple"
+url = "https://pypi.org/simple/"
 verify_ssl = true
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -20,7 +20,7 @@
         "requires": {},
         "sources": [
             {
-                "url": "https://pypi.python.org/simple",
+                "url": "https://pypi.org/simple/",
                 "verify_ssl": true
             }
         ]

--- a/README.rst
+++ b/README.rst
@@ -2,13 +2,13 @@ Requests: HTTP for Humans
 =========================
 
 .. image:: https://img.shields.io/pypi/v/requests.svg
-    :target: https://pypi.python.org/pypi/requests
+    :target: https://pypi.org/project/requests/
 
 .. image:: https://img.shields.io/pypi/l/requests.svg
-    :target: https://pypi.python.org/pypi/requests
+    :target: https://pypi.org/project/requests/
 
 .. image:: https://img.shields.io/pypi/pyversions/requests.svg
-    :target: https://pypi.python.org/pypi/requests
+    :target: https://pypi.org/project/requests/
 
 .. image:: https://codecov.io/github/requests/requests/coverage.svg?branch=master
     :target: https://codecov.io/github/requests/requests

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -51,7 +51,7 @@
   <p></p>
 
   <li><a href="https://github.com/requests/requests">Requests @ GitHub</a></li>
-  <li><a href="https://pypi.python.org/pypi/requests">Requests @ PyPI</a></li>
+  <li><a href="https://pypi.org/project/requests/">Requests @ PyPI</a></li>
   <li><a href="https://github.com/requests/requests/issues">Issue Tracker</a></li>
   <li><a href="http://docs.python-requests.org/en/latest/community/updates/#software-updates">Release History</a></li>
 </ul>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,13 +9,13 @@ Requests: HTTP for Humans
 Release v\ |version|. (:ref:`Installation <install>`)
 
 .. image:: https://img.shields.io/pypi/l/requests.svg
-    :target: https://pypi.python.org/pypi/requests
+    :target: https://pypi.org/project/requests/
 
 .. image:: https://img.shields.io/pypi/wheel/requests.svg
-    :target: https://pypi.python.org/pypi/requests
+    :target: https://pypi.org/project/requests/
 
 .. image:: https://img.shields.io/pypi/pyversions/requests.svg
-    :target: https://pypi.python.org/pypi/requests
+    :target: https://pypi.org/project/requests/
 
 .. image:: https://codecov.io/github/requests/requests/coverage.svg?branch=master
     :target: https://codecov.io/github/requests/requests

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -656,7 +656,7 @@ When you receive a response, Requests makes a guess at the encoding to
 use for decoding the response when you access the :attr:`Response.text
 <requests.Response.text>` attribute. Requests will first check for an
 encoding in the HTTP header, and if none is present, will use `chardet
-<https://pypi.python.org/pypi/chardet>`_ to attempt to guess the encoding.
+<https://pypi.org/project/chardet/>`_ to attempt to guess the encoding.
 
 The only time Requests will not do this is if no explicit charset
 is present in the HTTP headers **and** the ``Content-Type``


### PR DESCRIPTION
According to [1], the PyPI website of pypi.python.org has changed
to https://pypi.org. This patch updates all references to the
legacy site.

[1] https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html

Signed-off-by: Eric Brown <browne@vmware.com>