### PR TITLE
Nicer URL formatting with lists

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -9,6 +9,7 @@ requests (cookies, auth, proxies).
 """
 import os
 import sys
+import six
 import time
 from collections import Mapping
 from datetime import timedelta
@@ -486,7 +487,7 @@ class Session(SessionRedirectMixin):
         # Create the Request.
         req = Request(
             method=method.upper(),
-            url=url if isinstance(url, str) else '/'.join(list(map(str, url))),
+            url=url if isinstance(url, six.string_types) else '/'.join(list(map(str, url))),
             headers=headers,
             files=files,
             data=data or {},

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -486,7 +486,7 @@ class Session(SessionRedirectMixin):
         # Create the Request.
         req = Request(
             method=method.upper(),
-            url=url,
+            url=url if isinstance(url, str) else '/'.join(list(map(str, url))),
             headers=headers,
             files=files,
             data=data or {},


### PR DESCRIPTION
# Nicer URL formatting with lists

### Purpose

Using `['https://example.com', route1, route2]` as URL parameter as compared to `'https://example.com/{}/{}'.format(route1, route2)` or `'https://example.com/'+route1+'/'+route2`

### Examples

```python
import requests

slug = 1
r = requests.get(['https://api.jikan.me/anime', slug])
r.url
# 'https://api.jikan.me/anime/1'

category, item = 'jokes', 'random'
r = requests.get(['https://api.chucknorris.io', category, item])
r.url
# 'https://api.chucknorris.io/jokes/random'
```