### PR TITLE
Fix handling of zero-length files

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -486,7 +486,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             if files:
                 raise NotImplementedError('Streamed bodies and files are mutually exclusive.')
 
-            if length:
+            if length is not None:  # length may be zero.
                 self.headers['Content-Length'] = builtin_str(length)
             else:
                 self.headers['Transfer-Encoding'] = 'chunked'
@@ -514,7 +514,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         """Prepare Content-Length header based on request method and body"""
         if body is not None:
             length = super_len(body)
-            if length:
+            if length is not None:
                 # If length exists, set it. Otherwise, we fallback
                 # to Transfer-Encoding: chunked.
                 self.headers['Content-Length'] = builtin_str(length)

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -158,10 +158,10 @@ def super_len(o):
                 except (OSError, IOError):
                     total_length = 0
 
-    if total_length is None:
-        total_length = 0
+    if total_length is not None:
+        total_length = max(0, total_length - current_position)
 
-    return max(0, total_length - current_position)
+    return total_length
 
 
 def get_netrc_auth(url, raise_errors=False):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1813,8 +1813,8 @@ class TestRequests:
         file_obj = io.BytesIO(b'')
         r = requests.Request('POST', url, auth=auth, data=file_obj)
         prepared_request = r.prepare()
-        assert 'Transfer-Encoding' in prepared_request.headers
-        assert 'Content-Length' not in prepared_request.headers
+        assert 'Transfer-Encoding' not in prepared_request.headers
+        assert 'Content-Length' in prepared_request.headers
 
     def test_stream_with_auth_does_not_set_transfer_encoding_header(self, httpbin):
         """Ensure that a byte stream with size > 0 will not set both a Content-Length

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,7 +68,7 @@ class TestSuperLen:
             def seek(self, offset, whence):
                 pass
 
-        assert super_len(NoLenBoomFile()) == 0
+        assert super_len(NoLenBoomFile()) is None
 
     def test_string(self):
         assert super_len('Test') == 4
@@ -111,7 +111,7 @@ class TestSuperLen:
 
     def test_super_len_with_no_matches(self):
         """Ensure that objects without any length methods default to 0"""
-        assert super_len(object()) == 0
+        assert super_len(object()) is None
 
 
 class TestToKeyValList:


### PR DESCRIPTION
This was previously fixed in e7c9bbb96 and broken again in
4c82dbab6fc. Add a comment this time to prevent people from breaking
it again.