### PR TITLE
fix windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "pip install --disable-pip-version-check --user --upgrade pip"
+  - "python -m pip install --upgrade pip wheel"
   - "C:\\MinGW\\bin\\mingw32-make"
 
 test_script:


### PR DESCRIPTION
Appveyor isn't able to replace the running executable. We'll run it
from inside the interpreter to fix build issues. This is lifted from the fix over on urllib3/urllib3#1369 which was configured to run the same way.