### PR TITLE
add long_description_content_type to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
     version=about['__version__'],
     description=about['__description__'],
     long_description=readme + '\n\n' + history,
+    long_description_content_type='text/markdown',
     author=about['__author__'],
     author_email=about['__author_email__'],
     url=about['__url__'],


### PR DESCRIPTION
This will make the readme render correctly on pypi.

https://packaging.python.org/tutorials/distributing-packages/#description