### PR TITLE
Fix iter_lines boundary bug when CRLF straddles two chunks

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -785,6 +785,7 @@ class Response(object):
         """
 
         pending = None
+        carriage_return = u'\r' if decode_unicode else b'\r'
 
         for chunk in self.iter_content(chunk_size=chunk_size, decode_unicode=decode_unicode):
 
@@ -798,6 +799,8 @@ class Response(object):
 
             if lines and lines[-1] and chunk and lines[-1][-1] == chunk[-1]:
                 pending = lines.pop()
+            elif not delimiter and lines and chunk.endswith(carriage_return):
+                pending = lines.pop() + carriage_return
             else:
                 pending = None
 
@@ -805,6 +808,8 @@ class Response(object):
                 yield line
 
         if pending is not None:
+            if not delimiter:
+                pending = pending.rstrip(carriage_return)
             yield pending
 
     @property


### PR DESCRIPTION
In `Response.iter_lines`, if a `\r\n` sequence (the only multi-character line boundary) straddles two chunks, the `\r` and `\n` are treated as two separate boundaries. Consequently, `iter_lines` will yield one extra blank line, as an empty string.

This addresses the issue by checking if a chunk ends with `\r`, and when appropriate, leaving the trailing line in `pending` until the next chunk or EOF arrives.