### PR TITLE
fix appveyor

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,24 +1,24 @@
 [[source]]
 url = "https://pypi.org/simple/"
 verify_ssl = true
+name = "pypi"
 
 [dev-packages]
-
 pytest = ">=2.8.0"
 codecov = "*"
-"pytest-httpbin" = "==0.0.7"
-"pytest-mock" = "*"
-"pytest-cov" = "*"
-"pytest-xdist" = "*"
+pytest-httpbin = ">=0.0.7"
+pytest-mock = "*"
+pytest-cov = "*"
+pytest-xdist = "*"
 alabaster = "*"
-"readme-renderer" = "*"
+readme-renderer = "*"
 sphinx = "<=1.5.5"
 pysocks = "*"
 docutils = "*"
 "flake8" = "*"
 tox = "*"
 detox = "*"
-httpbin = "==0.5.0"
+httpbin = ">=0.7.0"
 
 [packages]
-"e1839a8" = {path = ".", editable = true, extras=["socks"]}
+"e1839a8" = {path = ".", editable = true, extras = ["socks"]}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,7 @@ install:
   # about it being out of date.
   - "python -m pip install --upgrade pip wheel"
   - "C:\\MinGW\\bin\\mingw32-make"
+  - "pipenv install -e .[socks] --skip-lock"
 
 test_script:
   - "C:\\MinGW\\bin\\mingw32-make coverage"


### PR DESCRIPTION
I don't know what's going on with Appveyor/Pipenv but it's no longer liking `-e .` installs out of the Pipfile. I went back to a version of Pipenv that we have successful builds for and it's still broken. I'd like to get builds fixed while we determine root cause.