### PR TITLE
Response.content minor perf improvement

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -824,7 +824,7 @@ class Response(object):
             if self.status_code == 0 or self.raw is None:
                 self._content = None
             else:
-                self._content = bytes().join(self.iter_content(CONTENT_CHUNK_SIZE)) or bytes()
+                self._content = b''.join(self.iter_content(CONTENT_CHUNK_SIZE)) or b''
 
         self._content_consumed = True
         # don't need to release the connection; that's been handled by urllib3


### PR DESCRIPTION
Python 2
```console
$ python -m timeit -s "blist = [b'foo', b'bar'];" "bytes().join(blist)"
1000000 loops, best of 3: 0.243 usec per loop
$ python -m timeit -s "blist = [b'foo', b'bar'];" "b''.join(blist)"
10000000 loops, best of 3: 0.125 usec per loop
```

Python 3
```console
$ python -m timeit -s "blist = [b'foo', b'bar'];" "bytes().join(blist)"
1000000 loops, best of 3: 0.285 usec per loop
$ python -m timeit -s "blist = [b'foo', b'bar'];" "b''.join(blist)"
10000000 loops, best of 3: 0.161 usec per loop
```