### PR TITLE
Allow urllib 1.23 (part 2)

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -57,10 +57,10 @@ def check_compatibility(urllib3_version, chardet_version):
     # Check urllib3 for compatibility.
     major, minor, patch = urllib3_version  # noqa: F811
     major, minor, patch = int(major), int(minor), int(patch)
-    # urllib3 >= 1.21.1, <= 1.22
+    # urllib3 >= 1.21.1, <= 1.23
     assert major == 1
     assert minor >= 21
-    assert minor <= 22
+    assert minor <= 23
 
     # Check chardet for compatibility.
     major, minor, patch = chardet_version.split('.')[:3]

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ if sys.argv[-1] == 'publish':
 
 packages = ['requests']
 
+# Don't forget to update check_compatibility() in requests/__init__.py
+# when bumping chardet and/or urllib3!
 requires = [
     'chardet>=3.0.2,<3.1.0',
     'idna>=2.5,<2.7',


### PR DESCRIPTION
Follow-up of https://github.com/requests/requests/pull/4669

This eliminates the following warning:
```
$ python -c 'import requests'
/usr/lib/python3.6/site-packages/requests/__init__.py:80: RequestsDependencyWarning: urllib3 (1.23) or chardet (3.0.4) doesn't match a supported version!
  RequestsDependencyWarning)
```