### PR TITLE
remove references to 2.6 support in documentation

### DIFF
--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -56,7 +56,6 @@ Python 3 Support?
 Yes! Here's a list of Python platforms that are officially
 supported:
 
-* Python 2.6
 * Python 2.7
 * Python 3.4
 * Python 3.5
@@ -70,7 +69,7 @@ These errors occur when :ref:`SSL certificate verification <verification>`
 fails to match the certificate the server responds with to the hostname
 Requests thinks it's contacting. If you're certain the server's SSL setup is
 correct (for example, because you can visit the site with your browser) and
-you're using Python 2.6 or 2.7, a possible explanation is that you need
+you're using Python 2.7, a possible explanation is that you need
 Server-Name-Indication.
 
 `Server-Name-Indication`_, or SNI, is an official extension to SSL where the

--- a/docs/dev/todo.rst
+++ b/docs/dev/todo.rst
@@ -51,7 +51,6 @@ Runtime Environments
 
 Requests currently supports the following versions of Python:
 
-- Python 2.6
 - Python 2.7
 - Python 3.4
 - Python 3.5

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -108,7 +108,7 @@ Requests is ready for today's web.
 - Chunked Requests
 - ``.netrc`` Support
 
-Requests officially supports Python 2.6–2.7 & 3.4–3.7, and runs great on PyPy.
+Requests officially supports Python 2.7 & 3.4–3.7, and runs great on PyPy.
 
 
 The User Guide

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,12 @@ if sys.argv[-1] == 'publish':
     os.system('twine upload dist/*')
     sys.exit()
 
+# pyOpenSSL version 18.0.0 dropped support for Python 2.6
+if sys.version_info < (2, 7):
+    PYOPENSSL_VERSION = 'pyOpenSSL >= 0.14, < 18.0.0'
+else:
+    PYOPENSSL_VERSION = 'pyOpenSSL >= 0.14'
+
 packages = ['requests']
 
 requires = [
@@ -96,7 +102,7 @@ setup(
     cmdclass={'test': PyTest},
     tests_require=test_requirements,
     extras_require={
-        'security': ['pyOpenSSL>=0.14', 'cryptography>=1.3.4', 'idna>=2.0.0'],
+        'security': [PYOPENSSL_VERSION, 'cryptography>=1.3.4', 'idna>=2.0.0'],
         'socks': ['PySocks>=1.5.6, !=1.5.7'],
         'socks:sys_platform == "win32" and (python_version == "2.7" or python_version == "2.6")': ['win_inet_pton'],
     },


### PR DESCRIPTION
This will remove our "official" support for 2.6 from the documentation only. We'll keep the work done to remove Python 2.6 code from the Requests code base (#4118) in the Requests3 branch so we don't forcibly break users installs with the 2.19.0 release.

@sigmavirus24 I looked at moving to urllib3's `secure` options, but wasn't immediately able to get `        'security': ['urllib3[secure]>=1.23']` working in our setup.py. That's likely the last step to close out #4659 if we're ok with urllib3 managing the security dependencies. I'll try to look closer later this week.