### PR TITLE
fixed urllib3 version dependency issue

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -57,10 +57,10 @@ def check_compatibility(urllib3_version, chardet_version):
     # Check urllib3 for compatibility.
     major, minor, patch = urllib3_version  # noqa: F811
     major, minor, patch = int(major), int(minor), int(patch)
-    # urllib3 >= 1.21.1, <= 1.22
+    # urllib3 >= 1.21.1, <= 1.23
     assert major == 1
     assert minor >= 21
-    assert minor <= 22
+    assert minor <= 23
 
     # Check chardet for compatibility.
     major, minor, patch = chardet_version.split('.')[:3]


### PR DESCRIPTION
The `requests` setup.py file allows this version range for `urllib3` `>=1.21.1,<1.24`. However, the `__init__.py` has assertion statements that only allow up to (and including) version `1.22`. In this PR, I'm updating the `assert` statements in `__init__.py` to be inline with the `setup.py` `requires`