### PR TITLE
Don't warn about compatibility with urllib3 v1.23

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -60,7 +60,7 @@ def check_compatibility(urllib3_version, chardet_version):
     # urllib3 >= 1.21.1, <= 1.22
     assert major == 1
     assert minor >= 21
-    assert minor <= 22
+    assert minor <= 23
 
     # Check chardet for compatibility.
     major, minor, patch = chardet_version.split('.')[:3]


### PR DESCRIPTION
Requests allows v1.23 in #4669, but the compatibility check at import
time still looks for 22. Bump the version to 23.

edit: I do wonder if these checks should just be removed since it's pinned in setup.py and pip doesn't let you install 23 anyway without #4669.

Signed-off-by: Jeremy Cline <jcline@redhat.com>