### PR TITLE
Update Python 2 doc links to Python 3

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -357,7 +357,7 @@ file-like object for your body::
              be set to the number of *bytes* in the file. Errors may occur if
              you open the file in *text mode*.
 
-.. _binary mode: https://docs.python.org/2/tutorial/inputoutput.html#reading-and-writing-files
+.. _binary mode: https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files
 
 
 .. _chunk-encoding:
@@ -414,7 +414,7 @@ To do that, just set files to a list of tuples of ``(form_field_name, file_info)
              be set to the number of *bytes* in the file. Errors may occur if
              you open the file in *text mode*.
 
-.. _binary mode: https://docs.python.org/2/tutorial/inputoutput.html#reading-and-writing-files
+.. _binary mode: https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files
 
 
 .. _event-hooks:

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -348,7 +348,7 @@ section.
              be set to the number of *bytes* in the file. Errors may occur if
              you open the file in *text mode*.
 
-.. _binary mode: https://docs.python.org/2/tutorial/inputoutput.html#reading-and-writing-files
+.. _binary mode: https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files
 
 
 Response Status Codes


### PR DESCRIPTION
The Python 3 docs are better maintained and are the future of Python development.