### PR TITLE
In docs, use intersphinx to link to Python documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -376,4 +376,7 @@ epub_exclude_files = ['search.html']
 # If false, no index is generated.
 #epub_use_index = True
 
-intersphinx_mapping = {'urllib3': ('https://urllib3.readthedocs.io/en/latest', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'urllib3': ('https://urllib3.readthedocs.io/en/latest', None),
+}

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -351,13 +351,11 @@ file-like object for your body::
     with open('massive-body', 'rb') as f:
         requests.post('http://some.url/streamed', data=f)
 
-.. warning:: It is strongly recommended that you open files in `binary mode`_.
-             This is because Requests may attempt to provide the
-             ``Content-Length`` header for you, and if it does this value will
-             be set to the number of *bytes* in the file. Errors may occur if
-             you open the file in *text mode*.
-
-.. _binary mode: https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files
+.. warning:: It is strongly recommended that you open files in :ref:`binary
+             mode <tut-files>`. This is because Requests may attempt to provide
+             the ``Content-Length`` header for you, and if it does this value
+             will be set to the number of *bytes* in the file. Errors may occur
+             if you open the file in *text mode*.
 
 
 .. _chunk-encoding:
@@ -408,13 +406,11 @@ To do that, just set files to a list of tuples of ``(form_field_name, file_info)
       ...
     }
 
-.. warning:: It is strongly recommended that you open files in `binary mode`_.
-             This is because Requests may attempt to provide the
-             ``Content-Length`` header for you, and if it does this value will
-             be set to the number of *bytes* in the file. Errors may occur if
-             you open the file in *text mode*.
-
-.. _binary mode: https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files
+.. warning:: It is strongly recommended that you open files in :ref:`binary
+             mode <tut-files>`. This is because Requests may attempt to provide
+             the ``Content-Length`` header for you, and if it does this value
+             will be set to the number of *bytes* in the file. Errors may occur
+             if you open the file in *text mode*.
 
 
 .. _event-hooks:

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -348,13 +348,11 @@ support this, but there is a separate package which does -
 For sending multiple files in one request refer to the :ref:`advanced <advanced>`
 section.
 
-.. warning:: It is strongly recommended that you open files in `binary mode`_.
-             This is because Requests may attempt to provide the
-             ``Content-Length`` header for you, and if it does this value will
-             be set to the number of *bytes* in the file. Errors may occur if
-             you open the file in *text mode*.
-
-.. _binary mode: https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files
+.. warning:: It is strongly recommended that you open files in :ref:`binary
+             mode <tut-files>`. This is because Requests may attempt to provide
+             the ``Content-Length`` header for you, and if it does this value
+             will be set to the number of *bytes* in the file. Errors may occur
+             if you open the file in *text mode*.
 
 
 Response Status Codes


### PR DESCRIPTION
The intersphinx extension can generate automatic links to the documentation of objects in other projects. It was already used for urllib3. For complete details on intersphinx, see:

http://www.sphinx-doc.org/en/master/ext/intersphinx.html