### PR TITLE
v2.19.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,11 @@ Release History
 dev
 +++
 
+- [Short description of non-trivial change.]
+
+2.19.0 (2018-06-12)
+++++++++++++++++++
+
 **Improvements**
 
 - Warn user about possible slowdown when using cryptography version < 1.3.4
@@ -13,17 +18,25 @@ dev
 - Fragments are now properly maintained across redirects. (RFC7231 7.1.2)
 - Removed use of cgi module to expedite library load time.
 - Added support for SHA-256 and SHA-512 digest auth algorithms.
+- Minor performance improvement to ``Request.content``.
+- Migrate to using collections.abc for 3.7 compatibility.
 
 **Bugfixes**
 
-- Parsing empty ``Link`` headers with ``parse_header_links()`` no longer return one bogus entry
+- Parsing empty ``Link`` headers with ``parse_header_links()`` no longer return one bogus entry.
 - Fixed issue where loading the default certificate bundle from a zip archive
-  would raise an ``IOError``
-- Fixed issue with unexpected ``ImportError`` on windows system which do not support ``winreg`` module
+  would raise an ``IOError``.
+- Fixed issue with unexpected ``ImportError`` on windows system which do not support ``winreg`` module.
 - DNS resolution in proxy bypass no longer includes the username and password in
   the request. This also fixes the issue of DNS queries failing on macOS.
 - Properly normalize adapter prefixes for url comparison.
 - Passing ``None`` as a file pointer to the ``files`` param no longer raises an exception.
+- Calling ``copy`` on a ``RequestsCookieJar`` will now preserve the cookie policy correctly.
+
+**Dependencies**
+
+- We now support idna v2.7.
+- We now support urllib3 v1.23.
 
 2.18.4 (2017-08-15)
 +++++++++++++++++++

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Requests is ready for today's web.
 - ``.netrc`` Support
 - Chunked Requests
 
-Requests officially supports Python 2.6–2.7 & 3.4–3.6, and runs great on PyPy.
+Requests officially supports Python 2.7 & 3.4–3.6, and runs great on PyPy.
 
 Installation
 ------------

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -57,10 +57,10 @@ def check_compatibility(urllib3_version, chardet_version):
     # Check urllib3 for compatibility.
     major, minor, patch = urllib3_version  # noqa: F811
     major, minor, patch = int(major), int(minor), int(patch)
-    # urllib3 >= 1.21.1, <= 1.22
+    # urllib3 >= 1.21.1, <= 1.23
     assert major == 1
     assert minor >= 21
-    assert minor <= 22
+    assert minor <= 23
 
     # Check chardet for compatibility.
     major, minor, patch = chardet_version.split('.')[:3]

--- a/requests/__version__.py
+++ b/requests/__version__.py
@@ -5,10 +5,10 @@
 __title__ = 'requests'
 __description__ = 'Python HTTP for Humans.'
 __url__ = 'http://python-requests.org'
-__version__ = '2.18.4'
-__build__ = 0x021804
+__version__ = '2.19.0'
+__build__ = 0x021900
 __author__ = 'Kenneth Reitz'
 __author_email__ = 'me@kennethreitz.org'
 __license__ = 'Apache 2.0'
-__copyright__ = 'Copyright 2017 Kenneth Reitz'
+__copyright__ = 'Copyright 2018 Kenneth Reitz'
 __cake__ = u'\u2728 \U0001f370 \u2728'

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ packages = ['requests']
 
 requires = [
     'chardet>=3.0.2,<3.1.0',
-    'idna>=2.5,<2.7',
+    'idna>=2.5,<2.8',
     'urllib3>=1.21.1,<1.24',
     'certifi>=2017.4.17'
 
@@ -90,7 +90,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',


### PR DESCRIPTION
363 days later, final prep steps for release.

* Updated HISTORY.rst.
* Moved version pin for idna to allow recent 2.7 release.
* Updated version warning for urllib3 to allow 1.23.
* Updated metadata dunders in __version__.py.
* Remove Python 2.6 trove classifier.