### PR TITLE
Do not alter status_codes docstring if it is None

### DIFF
--- a/requests/status_codes.py
+++ b/requests/status_codes.py
@@ -114,6 +114,7 @@ def _init():
 
     global __doc__
     __doc__ = (__doc__ + '\n' +
-               '\n'.join(doc(code) for code in sorted(_codes)))
+               '\n'.join(doc(code) for code in sorted(_codes))
+               if __doc__ is not None else None)
 
 _init()


### PR DESCRIPTION
Following https://github.com/requests/requests/pull/4394/files, with PYTHONOPTIMIZE=2, the current code breaks with TypeError due to None as the docstring. This broke dask tests https://github.com/dask/dask/pull/3594 .