### PR TITLE
Note that session() should not be used

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -735,7 +735,12 @@ def session():
     """
     Returns a :class:`Session` for context-management.
 
+    .. deprecated:: 1.0.0
+
+        This method has been deprecated since version 1.0.0 and is only kept for
+        backwards compatibility. New code should use :class:`~requests.sessions.Session`
+        to create a session. This may be removed at a future date.
+
     :rtype: Session
     """
-
     return Session()


### PR DESCRIPTION
According to requests/api.rst, the `Session` class was originally named session in 0.x. [When the class name was capitalized in 1.x](https://github.com/requests/requests/blob/265ef609d5903151374fba480aa81aafe68126ff/docs/api.rst#migrating-to-1x), the `session()` method was added for backwards compatibility.

This adds a docstring note that `requests.Session` should be used instead