### PR TITLE
Ignore '.idea' folder (PyCharm Settings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ t2.py
 dist
 
 /.mypy_cache/
+
+# PyCharm settings
+.idea/


### PR DESCRIPTION
When a project is opened in PyCharm, a '.idea' folder is automatically created to store user-specific settings. This can be safely ignored.

See https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder-