### PR TITLE
Issue #4690: Fixing problems when you post something like {'some-var':None}

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -448,8 +448,8 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             if files:
                 (body, content_type) = self._encode_files(files, data)
             else:
-                if data:
-                    body = self._encode_params(data)
+                body = self._encode_params(data) or None
+                if body:
                     if isinstance(data, basestring) or hasattr(data, 'read'):
                         content_type = None
                     else:


### PR DESCRIPTION
In #4690, an scenario is provided where if you make a post using as `data` a dictionary with empty values, the request library will treat this post as a chunked request. (More detail explanaition in my comment in the issue)

This PR fix that problem, creating the encoded data first to check if there is really data to sent in the data dictionary.