### PR TITLE
Add SemVer stability badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,9 @@ Requests: HTTP for Humans
 .. image:: https://img.shields.io/github/contributors/requests/requests.svg
     :target: https://github.com/requests/requests/graphs/contributors
 
+.. image:: https://api.dependabot.com/badges/compatibility_score?dependency-name=requests&package-manager=pip&version-scheme=semver
+    :target: https://dependabot.com/compatibility-score.html?dependency-name=requests&package-manager=pip&version-scheme=semver
+
 .. image:: https://img.shields.io/badge/Say%20Thanks-!-1EAEDB.svg
     :target: https://saythanks.io/to/kennethreitz
 


### PR DESCRIPTION
First of all, thanks for Requests!

Would you be up for adding a badge that shows how SemVer compliant / bug free new releases are? I was looking through the data we gather at Dependabot and realised we could put one together, so threw together the below:

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=requests&package-manager=pip&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=requests&package-manager=pip&version-scheme=semver)

If you click through then there's a description of how it's calculated - basically it takes all of the relevant updates Dependabot has done for projects that use Requests and checks what percentage of the time specs pass on the upgrade PR.

The score is slightly lower than 100% because some projects have flaky specs, but I'm working on filtering them out from the data, too :octocat:.