### PR TITLE
Change "StackOverflow" to "Stack Overflow"

### DIFF
--- a/.github/ISSUE_TEMPLATE/Custom.md
+++ b/.github/ISSUE_TEMPLATE/Custom.md
@@ -4,4 +4,4 @@ about: Guidance on using Requests.
 
 ---
 
-Please refer to our [StackOverflow tag](https://stackoverflow.com/questions/tagged/python-requests) for guidance.
+Please refer to our [Stack Overflow tag](https://stackoverflow.com/questions/tagged/python-requests) for guidance.

--- a/docs/community/support.rst
+++ b/docs/community/support.rst
@@ -7,12 +7,12 @@ Support
 
 If you have questions or issues about Requests, there are several options:
 
-StackOverflow
+Stack Overflow
 -------------
 
 If your question does not contain sensitive (possibly proprietary)
 information or can be properly anonymized, please ask a question on
-`StackOverflow <https://stackoverflow.com/questions/tagged/python-requests>`_
+`Stack Overflow <https://stackoverflow.com/questions/tagged/python-requests>`_
 and use the tag ``python-requests``.
 
 Send a Tweet


### PR DESCRIPTION
Add a missing space when referring to [Stack Overflow](https://stackoverflow.com).