### PR TITLE
Remove unused httpbin parameters

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1400,7 +1400,7 @@ class TestRequests:
         assert 'http://' in s2.adapters
         assert 'https://' in s2.adapters
 
-    def test_session_get_adapter_prefix_matching(self, httpbin):
+    def test_session_get_adapter_prefix_matching(self):
         prefix = 'https://example.com'
         more_specific_prefix = prefix + '/some/path'
 
@@ -1418,7 +1418,7 @@ class TestRequests:
         assert s.get_adapter(url_matching_more_specific_prefix) is more_specific_prefix_adapter
         assert s.get_adapter(url_not_matching_prefix) not in (prefix_adapter, more_specific_prefix_adapter)
 
-    def test_session_get_adapter_prefix_matching_mixed_case(self, httpbin):
+    def test_session_get_adapter_prefix_matching_mixed_case(self):
         mixed_case_prefix = 'hTtPs://eXamPle.CoM/MixEd_CAse_PREfix'
         url_matching_prefix = mixed_case_prefix + '/full_url'
 
@@ -1428,7 +1428,7 @@ class TestRequests:
 
         assert s.get_adapter(url_matching_prefix) is my_adapter
 
-    def test_session_get_adapter_prefix_matching_is_case_insensitive(self, httpbin):
+    def test_session_get_adapter_prefix_matching_is_case_insensitive(self):
         mixed_case_prefix = 'hTtPs://eXamPle.CoM/MixEd_CAse_PREfix'
         url_matching_prefix_with_different_case = 'HtTpS://exaMPLe.cOm/MiXeD_caSE_preFIX/another_url'
 
@@ -1795,12 +1795,12 @@ class TestRequests:
         proxies['one'].clear.assert_called_once_with()
         proxies['two'].clear.assert_called_once_with()
 
-    def test_proxy_auth(self, httpbin):
+    def test_proxy_auth(self):
         adapter = HTTPAdapter()
         headers = adapter.proxy_headers("http://user:pass@httpbin.org")
         assert headers == {'Proxy-Authorization': 'Basic dXNlcjpwYXNz'}
 
-    def test_proxy_auth_empty_pass(self, httpbin):
+    def test_proxy_auth_empty_pass(self):
         adapter = HTTPAdapter()
         headers = adapter.proxy_headers("http://user:@httpbin.org")
         assert headers == {'Proxy-Authorization': 'Basic dXNlcjo='}


### PR DESCRIPTION
httpbin is used to mock HTTP endpoints. In these methods, the parameter goes unused.