### PR TITLE
Misspelled 'proxy' parameter in docstring

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -378,7 +378,7 @@ class HTTPAdapter(BaseAdapter):
         when subclassing the
         :class:`HTTPAdapter <requests.adapters.HTTPAdapter>`.
 
-        :param proxies: The url of the proxy being used for this request.
+        :param proxy: The url of the proxy being used for this request.
         :rtype: dict
         """
         headers = {}


### PR DESCRIPTION
The 'proxy' parameter was misspelled as 'proxies' in the docstring.