### PR TITLE
Fixed pep8 issues in tests/test_help.py

### DIFF
--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -7,7 +7,8 @@ import pytest
 from requests.help import info
 
 
-@pytest.mark.skipif(sys.version_info[:2] != (2,6), reason="Only run on Python 2.6")
+@pytest.mark.skipif(sys.version_info[:2] != (2, 6),
+                    reason="Only run on Python 2.6")
 def test_system_ssl_py26():
     """OPENSSL_VERSION_NUMBER isn't provided in Python 2.6, verify we don't
     blow up in this case.
@@ -15,7 +16,8 @@ def test_system_ssl_py26():
     assert info()['system_ssl'] == {'version': ''}
 
 
-@pytest.mark.skipif(sys.version_info < (2,7), reason="Only run on Python 2.7+")
+@pytest.mark.skipif(sys.version_info < (2, 7),
+                    reason="Only run on Python 2.7+")
 def test_system_ssl():
     """Verify we're actually setting system_ssl when it should be available."""
     assert info()['system_ssl']['version'] != ''
@@ -35,6 +37,7 @@ def test_idna_without_version_attribute(mocker):
 
 
 def test_idna_with_version_attribute(mocker):
-    """Verify we're actually setting idna version when it should be available."""
+    """Verify we're actually setting idna version
+    when it should be available."""
     mocker.patch('requests.help.idna', new=VersionedPackage('2.6'))
     assert info()['idna'] == {'version': '2.6'}


### PR DESCRIPTION
Fixed pep8 issues below: 

test_help.py:10:47: E231 missing whitespace after ','
test_help.py:10:80: E501 line too long (83 > 79 characters)
test_help.py:18:42: E231 missing whitespace after ','
test_help.py:38:80: E501 line too long (81 > 79 characters)
