### PR TITLE
Fix assumed hostname when using a 'file' URI scheme adapter

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -706,6 +706,10 @@ def should_bypass_proxies(url, no_proxy):
         no_proxy = get_proxy('no_proxy')
     parsed = urlparse(url)
 
+    if parsed.hostname is None:
+        # URLs don't always have hostnames, e.g. file:/// urls.
+        return True
+
     if no_proxy:
         # We need to check whether we match here. We need to see if we match
         # the end of the hostname, both with and without the port.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -622,6 +622,7 @@ def test_urldefragauth(url, expected):
             ('http://172.16.1.12/', False),
             ('http://172.16.1.12:5000/', False),
             ('http://google.com:5000/v1.0/', False),
+            ('file:///some/path/on/disk', True),
     ))
 def test_should_bypass_proxies(url, expected, monkeypatch):
     """Tests for function should_bypass_proxies to check if proxy


### PR DESCRIPTION
Commit 2255c34a65b5b1353004dc8d49cc397cd794ec15 in https://github.com/requests/requests/pull/4427 makes the assumption that all URLs have hostnames.  Or perhaps the assumption was that `urlparse()` returns an empty string for the `hostname` attribute rather than `None`.  Either way, the assumption blows up both for `is_ipv4_address(parsed.hostname)` and also for

```python
host_with_port = parsed.hostname
if parsed.port:
    host_with_port += ':{0}'.format(parsed.port)
```

when `parsed.hostname` is `None`.  Example circumstances of where this all blows up is when a `NO_PROXY` environment variable is set during use of something like conda's [adapter](https://github.com/conda/conda/blob/4.5.5/conda/gateways/connection/adapters/localfs.py) to handle `file:///` urls.  It results in a stack trace like

```
Traceback (most recent call last):
  File "/home/circleci/conda/tests/gateways/test_connection.py", line 62, in test_local_file_adapter_200
    r = session.get(test_url)
  File "/opt/conda/lib/python3.6/site-packages/requests/sessions.py", line 525, in get
    return self.request('GET', url, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/requests/sessions.py", line 503, in request
    prep.url, proxies, stream, verify, cert
  File "/opt/conda/lib/python3.6/site-packages/requests/sessions.py", line 676, in merge_environment_settings
    env_proxies = get_environ_proxies(url, no_proxy=no_proxy)
  File "/opt/conda/lib/python3.6/site-packages/requests/utils.py", line 760, in get_environ_proxies
    if should_bypass_proxies(url, no_proxy=no_proxy):
  File "/opt/conda/lib/python3.6/site-packages/requests/utils.py", line 716, in should_bypass_proxies
    if is_ipv4_address(parsed.hostname):
  File "/opt/conda/lib/python3.6/site-packages/requests/utils.py", line 640, in is_ipv4_address
    socket.inet_aton(string_ip)
TypeError: inet_aton() argument 1 must be str, not None
```

I *think* the correct solution here is to just return `True` in the `should_bypass_proxies()` function when there is no hostname in the URL.  Definitely know that sending `None` to `inet_aton(string_ip)` or trying to add `None` to a port string definitely isn't correct.