### PR TITLE
Fix an invalid escape sequence

### DIFF
--- a/requests/status_codes.py
+++ b/requests/status_codes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-"""
+r"""
 The ``codes`` object defines a mapping from common names for HTTP statuses
 to their numerical codes, accessible either as attributes or as dictionary
 items.


### PR DESCRIPTION
Fix errors like this:
```
$ python -W error -c 'import requests'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/yen/Projects/requests/requests/__init__.py", line 114, in <module>
    from .models import Request, Response, PreparedRequest
  File "/Users/yen/Projects/requests/requests/models.py", line 43, in <module>
    from .status_codes import codes
  File "/Users/yen/Projects/requests/requests/status_codes.py", line 18
    """
SyntaxError: invalid escape sequence \o
```
Context: the [buildbot](https://github.com/buildbot/buildbot) test suite treats all warnings as errors.