### PR TITLE
 HTTPAdapter set response.peercert to keep SSL certificate details before connection release

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -274,6 +274,13 @@ class HTTPAdapter(BaseAdapter):
         response.raw = resp
         response.reason = response.raw.reason
 
+        # Keep x509 content prior to connection release
+        try:
+          response.peercert = response.raw._connection.sock.getpeercert()
+        # Not an SSL sock
+        except AttributeError:
+          pass
+
         if isinstance(req.url, bytes):
             response.url = req.url.decode('utf-8')
         else:

--- a/requests/models.py
+++ b/requests/models.py
@@ -586,7 +586,8 @@ class Response(object):
 
     __attrs__ = [
         '_content', 'status_code', 'headers', 'url', 'history',
-        'encoding', 'reason', 'cookies', 'elapsed', 'request'
+        'encoding', 'reason', 'cookies', 'elapsed', 'request',
+        'peercert'
     ]
 
     def __init__(self):
@@ -635,6 +636,10 @@ class Response(object):
         #: The :class:`PreparedRequest <PreparedRequest>` object to which this
         #: is a response.
         self.request = None
+
+        #: The certificate dictionary returned by :class 'ssl.SSLSocket'
+        #: or :class 'urllib3.contrib.pyopenssl.WrappedSocket' (python2)
+        self.peercert = None
 
     def __enter__(self):
         return self

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -696,6 +696,8 @@ def should_bypass_proxies(url, no_proxy):
 
     :rtype: bool
     """
+    # Prioritize lowercase environment variables over uppercase
+    # to keep a consistent behaviour with other http projects (curl, wget).
     get_proxy = lambda k: os.environ.get(k) or os.environ.get(k.upper())
 
     # First check whether no_proxy is defined. If it is, check that the URL


### PR DESCRIPTION
Hi guys,

To troubleshoot requests queries, I found useful to be able to access the connection SSL certificate details. Once the connection is closed, urllib3 call release_conn() and this information is not available afterwards, therefore I suggest to set a new attribute peercert in Response and set it in the HTTPAdapter.

Python 3.6

```python
(Pdb) type(response.raw._connection)
<class 'urllib3.connection.VerifiedHTTPSConnection'>
(Pdb) type(response.raw._connection.sock)
<class 'ssl.SSLSocket'>
````

```python
>>> resp = requests.get('https://s3.eu-west-1.amazonaws.com/')
>>> resp.peercert
{'subject': ((('commonName', 'aws.amazon.com'),),), 'issuer': ((('countryName', 'US'),), (('organizationName', 'Amazon'),), (('organizationalUnitName', 'Server CA 1B'),), (('commonName', 'Amazon'),)), 'version': 3, 'serialNumber': '0E9C9BE31387FA07A147D4406982B417', 'notBefore': 'Mar 28 00:00:00 2018 GMT', 'notAfter': 'Mar 28 12:00:00 2019 GMT', 'subjectAltName': (('DNS', 'aws.amazon.com'), ('DNS', 'www.aws.amazon.com'), ('DNS', 'aws-us-east-1.amazon.com'), ('DNS', 'aws-us-west-2.amazon.com'), ('DNS', 'amazonaws-china.com'), ('DNS', 'www.amazonaws-china.com')), 'OCSP': ('http://ocsp.sca1b.amazontrust.com',), 'caIssuers': ('http://crt.sca1b.amazontrust.com/sca1b.crt',), 'crlDistributionPoints': ('http://crl.sca1b.amazontrust.com/sca1b.crl',)}
```

With python 2.7 information are based on pyopenssl and less details are available though:

```
>>> resp = requests.get('https://s3.eu-west-1.amazonaws.com/')
>>> resp.peercert
{'subject': ((('commonName', u'aws.amazon.com'),),),
 'subjectAltName': [('DNS', 'aws.amazon.com'),
  ('DNS', 'www.aws.amazon.com'),
  ('DNS', 'aws-us-east-1.amazon.com'),
  ('DNS', 'aws-us-west-2.amazon.com'),
  ('DNS', 'amazonaws-china.com'),
  ('DNS', 'www.amazonaws-china.com')]}
```

```python
Pdb) type(response.raw._connection.sock)
<class 'urllib3.contrib.pyopenssl.WrappedSocket'>
(Pdb) type(response.raw._connection)
<class 'urllib3.connection.VerifiedHTTPSConnection'>
```
I also found people interested by this on [stackoverflow](https://stackoverflow.com/questions/16903528/how-to-get-response-ssl-certificate-from-requests-in-python)