### PR TITLE
make content-type's charset information case-insensitive

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -466,7 +466,7 @@ def _parse_content_type_header(header):
             if index_of_equals != -1:
                 key = param[:index_of_equals].strip(items_to_strip)
                 value = param[index_of_equals + 1:].strip(items_to_strip)
-            params_dict[key] = value
+            params_dict[key.lower()] = value
     return content_type, params_dict
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -481,6 +481,10 @@ def test_parse_dict_header(value, expected):
             ('application/json', {'charset': 'utf-8'})
         ),
         (
+            'application/json ; Charset=utf-8',
+            ('application/json', {'charset': 'utf-8'})
+        ),
+        (
             'text/plain',
             ('text/plain', {})
         ),


### PR DESCRIPTION
Fix bug described in https://github.com/requests/requests/issues/4748 .