### PR TITLE
Update all documentation to show Python 3.7 is supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Requests is ready for today's web.
 - ``.netrc`` Support
 - Chunked Requests
 
-Requests officially supports Python 2.7 & 3.4–3.6, and runs great on PyPy.
+Requests officially supports Python 2.7 & 3.4–3.7, and runs great on PyPy.
 
 Installation
 ------------

--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -60,6 +60,7 @@ supported:
 * Python 3.4
 * Python 3.5
 * Python 3.6
+* Python 3.7
 * PyPy
 
 What are "hostname doesn't match" errors?

--- a/docs/dev/todo.rst
+++ b/docs/dev/todo.rst
@@ -55,6 +55,7 @@ Requests currently supports the following versions of Python:
 - Python 3.4
 - Python 3.5
 - Python 3.6
+- Python 3.7
 - PyPy
 
 Google AppEngine is not officially supported although support is available


### PR DESCRIPTION
Official support was added in 6686ac173011a302c26c4aedbd992f96d6e58357.