### PR TITLE
Use a `with` statement when sending multipart data in quickstart guide 

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -297,7 +297,6 @@ POST a Multipart-Encoded File
 Requests makes it simple to upload Multipart-encoded files::
 
     >>> url = 'http://httpbin.org/post'
-    >>> files = {'file': open('report.xls', 'rb')}
     >>> with open('report.xls', 'rb') as f:
             r = requests.post(url, files={'file': f})
             r.text

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -311,10 +311,9 @@ Requests makes it simple to upload Multipart-encoded files::
 You can set the filename, content_type and headers explicitly::
 
     >>> url = 'http://httpbin.org/post'
-    >>> files = {'file': ('report.xls', open('report.xls', 'rb'), 'application/vnd.ms-excel', {'Expires': '0'})}
-
-    >>> r = requests.post(url, files=files)
-    >>> r.text
+    >>> with open('report.xls', 'rb') as f:
+            r = requests.post(url, files={'file': ('report.xls', f, 'application/vnd.ms-excel', {'Expires': '0'})})
+            r.text
     {
       ...
       "files": {

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -298,9 +298,9 @@ Requests makes it simple to upload Multipart-encoded files::
 
     >>> url = 'http://httpbin.org/post'
     >>> files = {'file': open('report.xls', 'rb')}
-
-    >>> r = requests.post(url, files=files)
-    >>> r.text
+    >>> with open('report.xls', 'rb') as f:
+            r = requests.post(url, files={'file': f})
+            r.text
     {
       ...
       "files": {


### PR DESCRIPTION
The original documentation implies that `requests` will close the file for you; this is not the case.  Since it is up to the user to release the resources, I think it should be reflected as such in the docs. 
