### PR TITLE
Adjust padding and button placements

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -100,7 +100,7 @@ body > div.document > div.sphinxsidebar > div > form > table > tbody > tr:nth-ch
 
 .native-flex {
   display: flex;
-  padding: 20px 20px 40px;
+  padding: 0 20px 30px;
   text-decoration: none;
 
   flex-flow: row nowrap;

--- a/docs/_templates/hacks.html
+++ b/docs/_templates/hacks.html
@@ -96,8 +96,8 @@
       <div class="native-details">
         <span class="native-company">#native_title#</span>
         <span class="native-desc">#native_desc#</span>
+        <span class="native-cta">#native_cta#</span>
       </div>
-      <span class="native-cta">#native_cta#</span>
     </div>
   </a>
 </div>


### PR DESCRIPTION
Move the CTA button so the floating version label doesn’t overlap with the ad. Make the expanded ad more compact to take less vertical space. Hope I don’t make more edit to the ads. 😟 