### PR TITLE
Tuple test_requirements was too long, PEP8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,14 @@ requires = [
     'certifi>=2017.4.17'
 
 ]
-test_requirements = ['pytest-httpbin==0.0.7', 'pytest-cov', 'pytest-mock', 'pytest-xdist', 'PySocks>=1.5.6, !=1.5.7', 'pytest>=2.8.0']
+test_requirements = [
+    'pytest-httpbin==0.0.7',
+    'pytest-cov',
+    'pytest-mock',
+    'pytest-xdist',
+    'PySocks>=1.5.6, !=1.5.7',
+    'pytest>=2.8.0'
+]
 
 about = {}
 with open(os.path.join(here, 'requests', '__version__.py'), 'r', 'utf-8') as f:


### PR DESCRIPTION
Broken a long line into multiple lines inside tuple parenthesis.