### PR TITLE
Improve parsing of header Digest

### DIFF
--- a/requests/auth.py
+++ b/requests/auth.py
@@ -253,7 +253,7 @@ class HTTPDigestAuth(AuthBase):
         if 'digest' in s_auth.lower() and self._thread_local.num_401_calls < 2:
 
             self._thread_local.num_401_calls += 1
-            pat = re.compile(r'digest ', flags=re.IGNORECASE)
+            pat = re.compile(r'digest( |\r\n)', flags=re.IGNORECASE)
             self._thread_local.chal = parse_dict_header(pat.sub('', s_auth, count=1))
 
             # Consume content and release the original connection


### PR DESCRIPTION
If this header is multiline we can found 'Digest\r\n  realm="..."\r\n ' instead of "Digest ".