### PR TITLE
Remove dead link to unixstickers.com

### DIFF
--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -20,8 +20,6 @@
 <h3>Stay Informed</h3>
 <p>Receive updates on new releases and upcoming projects.</p>
 
-<p><a href="http://www.unixstickers.com/stickers/coding_stickers/requests-shaped-sticker">Requests Stickers!</a></p>
-
 <p><a href="http://tinyletter.com/kennethreitz">Join Mailing List</a>.</p>
 
 <hr/>


### PR DESCRIPTION
The link does not link Requests stickers as the text suggests.