### PR TITLE
Use default OrderedDict from collection module

### DIFF
--- a/requests/compat.py
+++ b/requests/compat.py
@@ -43,9 +43,7 @@ if is_py2:
     import cookielib
     from Cookie import Morsel
     from StringIO import StringIO
-    from collections import Callable, Mapping, MutableMapping
-
-    from urllib3.packages.ordered_dict import OrderedDict
+    from collections import Callable, Mapping, MutableMapping, OrderedDict
 
     builtin_str = str
     bytes = str


### PR DESCRIPTION
Due urllib3 doesn't contain OrderedDict implementation in 1.24 version
    requests should use default implementation OrderedDict