### PR TITLE
Allow urllib3 1.24

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ packages = ['requests']
 requires = [
     'chardet>=3.0.2,<3.1.0',
     'idna>=2.5,<2.8',
-    'urllib3>=1.21.1,<1.24',
+    'urllib3>=1.21.1,<1.25',
     'certifi>=2017.4.17'
 
 ]


### PR DESCRIPTION
A new version of has been released. Most notably it ships https://github.com/urllib3/urllib3/pull/1346

That, plus https://github.com/requests/requests/pull/4718 on our side will resolve https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-18074. We just need to release after merging this.

cc @sigmavirus24 @nateprewitt 