### PR TITLE
proper handling for default ports in auth stripping

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -38,6 +38,8 @@ NETRC_FILES = ('.netrc', '_netrc')
 
 DEFAULT_CA_BUNDLE_PATH = certs.where()
 
+DEFAULT_PORTS = {'http': 80, 'https': 443}
+
 
 if sys.platform == 'win32':
     # provide a proxy_bypass version on Windows without DNS lookups

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1611,6 +1611,17 @@ class TestRequests:
         s = requests.Session()
         assert s.should_strip_auth('http://example.com:1234/foo', 'https://example.com:4321/bar')
 
+    @pytest.mark.parametrize(
+        'old_uri, new_uri', (
+            ('https://example.com:443/foo', 'https://example.com/bar'),
+            ('http://example.com:80/foo', 'http://example.com/bar'),
+            ('https://example.com/foo', 'https://example.com:443/bar'),
+            ('http://example.com/foo', 'http://example.com:80/bar')
+        ))
+    def test_should_strip_auth_default_port(self, old_uri, new_uri):
+        s = requests.Session()
+        assert not s.should_strip_auth(old_uri, new_uri)
+
     def test_manual_redirect_with_partial_body_read(self, httpbin):
         s = requests.Session()
         r1 = s.get(httpbin('redirect/2'), allow_redirects=False, stream=True)


### PR DESCRIPTION
This is an attempt to address the default port issues presented in #4850. Our recent changes around auth stripping to handle downgrade attacks in #4718 broke compatibility for cases like http://example.com:80 -> http://example.com. This will allow the use of "default" ports and no port interchangeably.

If you get a moment @sigmavirus24, I'd like a second pair of eyes on this. I'm not ecstatic about continuing to expand this function, but I don't think there's an easier simplification of what we have.