### PR TITLE
Remove unnecessary travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ sudo: false
 language: python
 # command to install dependencies
 install: "make"
-# command to run tests
-script:
-  - |
-    if [[ "$TRAVIS_PYTHON_VERSION" != "2.6" ]] ; then make test-readme; fi
-  - make ci
 cache: pip
 jobs:
   include:


### PR DESCRIPTION
Each job already defines its `script`, so need 
to define it at the top level.