### PR TITLE
fix issue when an object overrode __getattr__

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -90,7 +90,7 @@ class RequestEncodingMixin(object):
 
         if isinstance(data, (str, bytes)):
             return data
-        elif hasattr(data, 'read'):
+        elif hasattr(data, 'read') and callable(data.read):
             return data
         elif hasattr(data, '__iter__'):
             result = []


### PR DESCRIPTION
when a class overrode `__getattr__` method and always return something even `None`, this check would fail.
adding `callable` check to ensure there is an existing method `read`.

below is fail case which is used widely to use dot access for a dict:
```
class DotDict(dict):
    """dot.notation access to dictionary attributes"""
    __setattr__ = dict.__setitem__
    __delattr__ = dict.__delitem__

    def __getattr__(self, attr):
        try:
            return self.__getitem__(attr)
        except KeyError:
            return None
```
