### PR TITLE
Set iter_lines() decode_unicode default to False

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -781,7 +781,7 @@ class Response(object):
 
         return chunks
 
-    def iter_lines(self, chunk_size=ITER_CHUNK_SIZE, decode_unicode=None, delimiter=None):
+    def iter_lines(self, chunk_size=ITER_CHUNK_SIZE, decode_unicode=False, delimiter=None):
         """Iterates over the response data, one line at a time.  When
         stream=True is set on the request, this avoids reading the
         content at once into memory for large responses.


### PR DESCRIPTION
The docs just read a bit strange with `decode_unicode=None` as opposed to `False`.