### PR TITLE
Simplify tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,5 +4,4 @@ envlist = py27,py34,py35,py36
 [testenv]
 
 commands =
-    pip install -e .[socks]
     python setup.py test


### PR DESCRIPTION
Tox installs the package to the virtualenv by default. PySocks is
already included in test_requirements. Don't need to install these
explicitly.