### PR TITLE
get(), request(): fix documentation of 'params'

### DIFF
--- a/requests/api.py
+++ b/requests/api.py
@@ -19,7 +19,7 @@ def request(method, url, **kwargs):
     :param method: method for the new :class:`Request` object.
     :param url: URL for the new :class:`Request` object.
     :param params: (optional) Dictionary, list of tuples or bytes to send
-        in the body of the :class:`Request`.
+        in the query string for the :class:`Request`.
     :param data: (optional) Dictionary, list of tuples, bytes, or file-like
         object to send in the body of the :class:`Request`.
     :param json: (optional) A JSON serializable Python object to send in the body of the :class:`Request`.
@@ -65,7 +65,7 @@ def get(url, params=None, **kwargs):
 
     :param url: URL for the new :class:`Request` object.
     :param params: (optional) Dictionary, list of tuples or bytes to send
-        in the body of the :class:`Request`.
+        in the query string for the :class:`Request`.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
     :return: :class:`Response <Response>` object
     :rtype: requests.Response


### PR DESCRIPTION
'params' is sent to the query string, not the body.