### PR TITLE
iter_content() checks for < 1 chunk_size

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -769,7 +769,7 @@ class Response(object):
             raise StreamConsumedError()
         elif chunk_size is not None and not isinstance(chunk_size, int):
             raise TypeError("chunk_size must be an int, it is instead a %s." % type(chunk_size))
-        elif chunk_size < 1:
+        elif chunk_size is not None and chunk_size < 1:
             raise ValueError("chunk_size must be a positive integer, got "+str(chunk_size))
         # simulate reading small chunks of the content
         reused_chunks = iter_slices(self._content, chunk_size)

--- a/requests/models.py
+++ b/requests/models.py
@@ -769,6 +769,8 @@ class Response(object):
             raise StreamConsumedError()
         elif chunk_size is not None and not isinstance(chunk_size, int):
             raise TypeError("chunk_size must be an int, it is instead a %s." % type(chunk_size))
+        elif chunk_size < 1:
+            raise ValueError("chunk_size must be a positive integer, got "+str(chunk_size))
         # simulate reading small chunks of the content
         reused_chunks = iter_slices(self._content, chunk_size)
 


### PR DESCRIPTION
With requests v2.20.1, supplying a value of 0 for `chunk_size` causes `iter_content()` to hang. This made debugging code that dynamically computes a value for `chunk_size` difficult. These two lines explicitly enforce `chunk_size` being a positive integer.