### PR TITLE
Include Python Information with default User Agent

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -796,7 +796,13 @@ def default_user_agent(name="python-requests"):
 
     :rtype: str
     """
-    return '%s/%s' % (name, __version__)
+    try:
+        python_name = sys.subversion[0]
+    except AttributeError:
+        python_name = sys.implementation.name
+    user_agent = '%s/%s %s' % (name, __version__, python_name)
+    user_agent += ' {}.{}.{}-{}{}'.format(*sys.version_info)
+    return user_agent
 
 
 def default_headers():


### PR DESCRIPTION
- A lot of people use default user agent with requests
- Lets include Python runtime + version information
- Allows servers to know some more useful information about their users e.g. PyPI / Warehouse

This will help pypistats.org for example - https://github.com/crflynn/pypistats.org/issues/13

Open to other ideas here. Just throwing this up to start the discussion.