### PR TITLE
Make requests compliant with PEP 476

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -701,11 +701,13 @@ class Session(SessionRedirectMixin):
             for (k, v) in env_proxies.items():
                 proxies.setdefault(k, v)
 
-            # Look for requests environment configuration and be compatible
-            # with cURL.
+            # Look for requests CA_BUNDLE configuration in the environment. Be
+            # compatible with cURL and PEP 476 / OpenSSL.
             if verify is True or verify is None:
                 verify = (os.environ.get('REQUESTS_CA_BUNDLE') or
-                          os.environ.get('CURL_CA_BUNDLE'))
+                          os.environ.get('CURL_CA_BUNDLE') or
+                          os.environ.get('SSL_CERT_FILE') or
+                          os.environ.get('SSL_CERT_DIR'))
 
         # Merge all the kwargs.
         proxies = merge_setting(proxies, self.proxies)


### PR DESCRIPTION
Enables loading of certificate bundles from SSL_CERT_FILE or
SSL_CERT_DIR as mentioned in https://legacy.python.org/dev/peps/pep-0476/

Current patch keeps backwards compatibility by preferring the more
specific options and using the new ones only as fallbacks.

Fixes: #2899