### PR TITLE
Fixes: TestSuperLen class

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -19,7 +19,7 @@ from .cookies import (
 from .models import Request, PreparedRequest, DEFAULT_REDIRECT_LIMIT
 from .hooks import default_hooks, dispatch_hook
 from ._internal_utils import to_native_string
-from .utils import to_key_val_list, default_headers, DEFAULT_PORTS
+from .utils import to_key_val_list, default_headers, default_ports
 from .exceptions import (
     TooManyRedirects, InvalidSchema, ChunkedEncodingError, ContentDecodingError)
 
@@ -132,7 +132,7 @@ class SessionRedirectMixin(object):
         # Handle default port usage corresponding to scheme.
         changed_port = old_parsed.port != new_parsed.port
         changed_scheme = old_parsed.scheme != new_parsed.scheme
-        default_port = (DEFAULT_PORTS.get(old_parsed.scheme, None), None)
+        default_port = (default_ports().get(old_parsed.scheme, None), None)
         if (not changed_scheme and old_parsed.port in default_port
                 and new_parsed.port in default_port):
             return False

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -38,8 +38,6 @@ NETRC_FILES = ('.netrc', '_netrc')
 
 DEFAULT_CA_BUNDLE_PATH = certs.where()
 
-DEFAULT_PORTS = {'http': 80, 'https': 443}
-
 
 if sys.platform == 'win32':
     # provide a proxy_bypass version on Windows without DNS lookups
@@ -810,6 +808,14 @@ def default_headers():
         'Connection': 'keep-alive',
     })
 
+def default_ports():
+  """
+  :rtype: requests.structures.CaseInsensitiveDict
+  """
+  return CaseInsensitiveDict({
+    'http': 80,
+    'https': 443,
+  })
 
 def parse_header_links(value):
     """Return a list of parsed link headers proxies.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,7 +30,7 @@ from .compat import StringIO, cStringIO
 class TestSuperLen:
     @pytest.mark.parametrize(
         'stream, value', [
-            (StringIO, 'Test'),
+            (StringIO.StringIO, 'Test'),
             (BytesIO, b'Test'),
             pytest.param(cStringIO, 'Test', marks=pytest.mark.skipif),
         ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,13 +28,13 @@ from .compat import StringIO, cStringIO
 
 
 class TestSuperLen:
-
     @pytest.mark.parametrize(
-        'stream, value', (
-            (StringIO.StringIO, 'Test'),
+        'stream, value', [
+            (StringIO, 'Test'),
             (BytesIO, b'Test'),
-            pytest.mark.skipif('cStringIO is None')((cStringIO, 'Test')),
-        ))
+            pytest.param(cStringIO, 'Test', marks=pytest.mark.skipif),
+        ]
+    )
     def test_io_streams(self, stream, value):
         """Ensures that we properly deal with different kinds of IO streams."""
         assert super_len(stream()) == 0


### PR DESCRIPTION
Pytest itself would fail, until I fixed the semantics of the pytest params in the decorator for `test_io_streams`. I am not certain unittests are being used currently, as many tests failed prior to changing anything. Am I not using them correctly?

I also wanted to start a discussion and share thoughts on default_ports, I believe it should be written in the same manner as default_headers.